### PR TITLE
Notebook task speed increase via manifest injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,30 @@ Each task calls a shared runner notebook (`run_dbt_command.py`) with parameteriz
 - Supports running the dbt process on job compute via `--job-cluster-key` (SQL execution still uses the warehouse in `profiles.yml`)
 - More flexibility - The runner notebook is editable. Want to load secrets from a scope before dbt runs? Run dbt, then call a Python API with the result? Emit a Slack message on failure? Tag the run with Git SHA? Add a few lines to the runner notebook.
 
+#### Faster parsing on large projects (pre-built manifest)
+
+On large projects with many parallel tasks, most of each task's time is dbt **parsing** (re-reading
+and content-hashing every project file and rebuilding the DAG), paid by every task and amplified by
+contention on the shared workspace filesystem. The notebook runner skips this when a pre-built
+manifest is present: if `target/partial_parse.msgpack` sits next to the project, it is injected into
+`dbtRunner` so dbt skips parsing, and each task writes its artifacts to a private local dir instead
+of the shared project `target/`.
+
+**Which file, when.** `manifest.json` and `partial_parse.msgpack` are both produced by a single local
+`dbt parse` (or `dbt compile`), but they are consumed at different stages — and **only the msgpack is
+needed at runtime**:
+
+| File | Stage | Role |
+|---|---|---|
+| `target/manifest.json` | Job generation (local) | **Read** by the factory (`--dbt-manifest-path`) to build the task DAG. Never used at runtime. |
+| `target/partial_parse.msgpack` | Task runtime | **Read** by every task and injected into `dbtRunner` to skip parsing. **The only file you sync to the workspace**; tasks never rewrite it. |
+| per-task local `target/` | Task runtime | **Written** by dbt (compiled SQL, etc.) to a private local dir, off the shared project `target/`. |
+
+Build the msgpack with the **same dbt version your tasks run** — a mismatch makes the runner fall back
+to a normal parse (so it is always safe to leave enabled). Optionally add `--extra-dbt-command-options
+"--no-write-json --no-populate-cache"` to also skip JSON artifact writes and the warehouse
+relation-cache scan.
+
 
 ## End-to-end example
 

--- a/README.md
+++ b/README.md
@@ -288,18 +288,16 @@ Each task calls a shared runner notebook (`run_dbt_command.py`) with parameteriz
 - Supports running the dbt process on job compute via `--job-cluster-key` (SQL execution still uses the warehouse in `profiles.yml`)
 - More flexibility - The runner notebook is editable. Want to load secrets from a scope before dbt runs? Run dbt, then call a Python API with the result? Emit a Slack message on failure? Tag the run with Git SHA? Add a few lines to the runner notebook.
 
-#### Faster parsing on large projects (pre-built manifest)
+#### Faster parsing on large projects (pre-built msgpack)
 
 On large projects with many parallel tasks, most of each task's time is dbt **parsing** (re-reading
 and content-hashing every project file and rebuilding the DAG), paid by every task and amplified by
-contention on the shared workspace filesystem. The notebook runner skips this when a pre-built
-manifest is present: if `target/partial_parse.msgpack` sits next to the project, it is injected into
-`dbtRunner` so dbt skips parsing, and each task writes its artifacts to a private local dir instead
-of the shared project `target/`.
+contention on the shared workspace filesystem. The notebook runner skips parsing when a pre-built
+msgpack sits next to the project: it loads `target/partial_parse.msgpack` into a manifest and injects
+that into `dbtRunner`, and each task writes its artifacts to a private local dir instead of the shared
+project `target/`.
 
-**Which file, when.** `manifest.json` and `partial_parse.msgpack` are both produced by a single local
-`dbt parse` (or `dbt compile`), but they are consumed at different stages — and **only the msgpack is
-needed at runtime**:
+**Which file, when.** A single local `dbt parse` produces both files:
 
 | File | Stage | Role |
 |---|---|---|
@@ -307,8 +305,7 @@ needed at runtime**:
 | `target/partial_parse.msgpack` | Task runtime | **Read** by every task and injected into `dbtRunner` to skip parsing. **The only file you sync to the workspace**; tasks never rewrite it. |
 | per-task local `target/` | Task runtime | **Written** by dbt (compiled SQL, etc.) to a private local dir, off the shared project `target/`. |
 
-Build the msgpack with the **same dbt version your tasks run** — a mismatch makes the runner fall back
-to a normal parse (so it is always safe to leave enabled). Optionally add `--extra-dbt-command-options
+Build the msgpack with the **same dbt version your tasks run**. Optionally add `--extra-dbt-command-options
 "--no-write-json --no-populate-cache"` to also skip JSON artifact writes and the warehouse
 relation-cache scan.
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,12 @@ Build the msgpack with the **same dbt version your tasks run**. Optionally add `
 "--no-write-json --no-populate-cache"` to also skip JSON artifact writes and the warehouse
 relation-cache scan.
 
+> **Note:** In this mode a task's run artifacts (`run_results.json`, compiled SQL, etc.) are written to
+> a private local dir and are **not** synced back to the shared workspace `target/`. The local dir is
+> deleted when the task ends, so don't rely on inspecting workspace `target/` artifacts after a run. If
+> a task fails, the failure detail is still surfaced in the task log. Leave the msgpack absent to fall
+> back to the default behavior (parse per task, artifacts in the shared `target/`).
+
 
 ## End-to-end example
 

--- a/src/databricks_dbt_factory/notebook/run_dbt_command.py
+++ b/src/databricks_dbt_factory/notebook/run_dbt_command.py
@@ -3,6 +3,7 @@
 import json
 import os
 import shlex
+import tempfile
 
 from dbt.cli.main import dbtRunner
 
@@ -45,8 +46,23 @@ if project_directory:
 os.makedirs("logs", exist_ok=True)
 os.makedirs("target", exist_ok=True)
 
+manifest = None
+prebuilt_manifest_path = os.path.join("target", "partial_parse.msgpack")
+if os.path.exists(prebuilt_manifest_path):
+    try:
+        from dbt.contracts.graph.manifest import Manifest
+
+        with open(prebuilt_manifest_path, "rb") as f:
+            manifest = Manifest.from_msgpack(f.read())
+        manifest.build_flat_graph()
+        local_dir = tempfile.mkdtemp(prefix="dbt_local_")
+        os.environ["DBT_TARGET_PATH"] = local_dir
+        os.environ["DBT_LOG_PATH"] = local_dir
+    except Exception:
+        manifest = None
+
 try:
-    runner = dbtRunner()
+    runner = dbtRunner(manifest=manifest)
 
     for command_str in json.loads(dbt_commands):
         command_str = command_str.strip()
@@ -74,3 +90,5 @@ try:
 finally:
     os.environ.pop("DBT_ACCESS_TOKEN", None)
     os.environ.pop("DBT_HOST", None)
+    os.environ.pop("DBT_TARGET_PATH", None)
+    os.environ.pop("DBT_LOG_PATH", None)

--- a/src/databricks_dbt_factory/notebook/run_dbt_command.py
+++ b/src/databricks_dbt_factory/notebook/run_dbt_command.py
@@ -3,6 +3,7 @@
 import json
 import os
 import shlex
+import shutil
 import tempfile
 
 from dbt.cli.main import dbtRunner
@@ -46,7 +47,12 @@ if project_directory:
 os.makedirs("logs", exist_ok=True)
 os.makedirs("target", exist_ok=True)
 
+# If a pre-built msgpack sits next to the project, deserialize it into a manifest and inject it into
+# dbtRunner to skip dbt's parse phase (re-reading/hashing every file + DAG rebuild) on each task. Each
+# task then writes artifacts to a private local dir (DBT_TARGET_PATH/DBT_LOG_PATH) to avoid contention
+# on the shared workspace `target/`. Falls back to a normal parse if the msgpack is absent or unusable.
 manifest = None
+local_dir = None
 prebuilt_manifest_path = os.path.join("target", "partial_parse.msgpack")
 if os.path.exists(prebuilt_manifest_path):
     try:
@@ -94,3 +100,7 @@ finally:
     os.environ.pop("DBT_HOST", None)
     os.environ.pop("DBT_TARGET_PATH", None)
     os.environ.pop("DBT_LOG_PATH", None)
+    # Remove the private per-task target/log dir; on reused (all-purpose) clusters these
+    # would otherwise accumulate under the system temp dir for the life of the cluster.
+    if local_dir:
+        shutil.rmtree(local_dir, ignore_errors=True)

--- a/src/databricks_dbt_factory/notebook/run_dbt_command.py
+++ b/src/databricks_dbt_factory/notebook/run_dbt_command.py
@@ -58,7 +58,9 @@ if os.path.exists(prebuilt_manifest_path):
         local_dir = tempfile.mkdtemp(prefix="dbt_local_")
         os.environ["DBT_TARGET_PATH"] = local_dir
         os.environ["DBT_LOG_PATH"] = local_dir
-    except Exception:
+        print(f"[dbt-factory] injecting pre-built manifest from {prebuilt_manifest_path} (skipping dbt parse)")
+    except Exception as e:
+        print(f"[dbt-factory] manifest injection unavailable, falling back to dbt parse: {e}")
         manifest = None
 
 try:


### PR DESCRIPTION
## Summary

- **Notebook task type speed improvements** 
- noticed for large projects (hence large msgpack/manifest files) and large # of parallel tasks using shared WSFS leads to a significant runtime increase
- allowing for skipping parsing entirely with pre-built msgpack utilization and injecting the manifest via dbtRunner(manifest=...)
- rewriting of artifacts to local directory on task level

- **Update README** with new hints regarding speed optimization & utilization of pre-built msgpack

## Test plan
- multiple before & after change comparison runs + time measurements & task level log inspections
- used simulated large base project 3,000 models + 6,000 tests + 1,000 macros
Full details in [doc](https://docs.google.com/document/d/1XummxZ5nAEjutfVU3ZUNoLJfQmg73TgSO6JRAKcsL0M/edit?usp=sharing) 

