### PR TITLE
Validate test_data fixtures against the Databricks Asset Bundle schema

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,5 +43,9 @@ jobs:
       - name: Install Hatch
         run: pip install hatch==1.17.1
 
+      - name: Install Databricks CLI
+        # Required to generate the DAB schema for tests/integration/test_bundle_schema.py.
+        uses: databricks/setup-cli@dd60b7b133203edca3e8f08b1e053c43a979296e # v1.8.0
+
       - name: Integration tests
         run: make integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,13 @@ make integration
 
 `make integration` builds the package and drives the installed `databricks_dbt_factory` CLI as a
 real subprocess against the fixtures in `tests/test_data`, comparing the generated job spec to the
-committed golden files. It requires no Databricks workspace and runs in CI alongside the unit tests.
+committed golden files. It also validates every fixture against the Databricks Asset Bundle schema
+(generated on the fly with `databricks bundle schema`) to ensure the generated specs are valid DABs.
+It requires no Databricks workspace and runs in CI alongside the unit tests.
+
+The bundle-schema validation needs the [Databricks CLI](https://docs.databricks.com/dev-tools/cli/)
+on your `PATH`. If it is not installed those tests are skipped locally (but they are required and
+run in CI, where the CLI is always installed).
 ## Local installation and execution
 
 ```shell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
   "black~=24.3.0",
   "coverage[toml]~=7.4.4",
   "databricks-labs-pylint~=0.5",
+  "jsonschema~=4.21",
   "mypy~=1.9.0",
   "pylint~=3.3.1",
   "pylint-pytest==2.0.0a0",

--- a/tests/integration/test_bundle_schema.py
+++ b/tests/integration/test_bundle_schema.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 import subprocess
+import warnings
 from pathlib import Path
 
 import jsonschema
@@ -56,22 +57,22 @@ def _job_spec_fixtures() -> list[Path]:
 
 
 def _neutralize_unsupported_regex(node):
-    """Recursively replace ``pattern`` regexes that Python's ``re`` cannot compile.
+    """Recursively rewrite ``pattern`` regexes that Python's ``re`` cannot compile.
 
-    Newer Databricks CLIs emit ECMA-262 patterns (e.g. ``\\p{...}``) that Python's ``re``
-    module rejects with ``bad escape``, which crashes jsonschema when a matching string
-    field is validated. We validate structure (unknown fields, types, required, enums)
-    rather than string patterns, so an unparseable ``pattern`` is replaced with a permissive
-    ``".*"`` instead of being deleted.
+    The Databricks CLI emits ECMA-262 patterns using Unicode property escapes such as
+    ``\\p{L}`` (letters) and ``\\p{N}`` (numbers) — e.g. the ``${var.name}`` interpolation
+    pattern — which Python's ``re`` module rejects with ``bad escape``, crashing jsonschema
+    when a matching string field is validated. We translate those escapes to their Python
+    equivalents so the pattern still means the same thing.
 
-    We replace rather than delete because ``pattern`` discriminates ``oneOf`` branches in
-    the bundle schema (e.g. ``git_provider`` has a patterned-string branch and an enum
-    branch); deleting it would collapse the two into identical ``{"type": "string"}``
-    schemas and cause spurious ``oneOf`` failures.
+    We translate rather than delete or blanket-replace with ``.*`` because ``pattern``
+    discriminates ``oneOf`` branches (e.g. ``git_provider`` is *either* a known-provider
+    enum *or* a ``${var...}`` reference). Collapsing the pattern to ``.*`` would make a
+    literal like ``gitHub`` match both branches and cause a spurious ``oneOf`` failure.
     """
     if isinstance(node, dict):
         return {
-            key: (_neutralized_pattern(value) if key == "pattern" else _neutralize_unsupported_regex(value))
+            key: (_translate_pattern(value) if key == "pattern" else _neutralize_unsupported_regex(value))
             for key, value in node.items()
         }
     if isinstance(node, list):
@@ -79,15 +80,25 @@ def _neutralize_unsupported_regex(node):
     return node
 
 
-def _neutralized_pattern(value):
-    """Return the pattern unchanged if Python's ``re`` can compile it, else a permissive ``.*``."""
+def _translate_pattern(value):
+    """Translate ECMA Unicode property escapes to Python-compatible character classes.
+
+    ``\\p{L}`` -> ``[^\\W\\d_]`` (any letter) and ``\\p{N}`` -> ``\\d`` (any digit). Falls
+    back to a permissive ``.*`` only if the result still cannot compile, so a genuinely
+    exotic future pattern degrades gracefully instead of crashing the suite.
+    """
     if not isinstance(value, str):
         return value
+    translated = value.replace(r"\p{L}", r"[^\W\d_]").replace(r"\p{N}", r"\d")
     try:
-        re.compile(value)
+        with warnings.catch_warnings():
+            # Translating `[\p{L}\p{N}]` yields a nested set `[[^\W\d_]\d]`, which Python
+            # accepts but warns about; the pattern still means "letters or digits".
+            warnings.simplefilter("ignore", FutureWarning)
+            re.compile(translated)
     except re.error:
         return ".*"
-    return value
+    return translated
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_bundle_schema.py
+++ b/tests/integration/test_bundle_schema.py
@@ -15,6 +15,7 @@ duplicated, drift-prone copy — CI installs the Databricks CLI and generates it
 
 import json
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -54,6 +55,41 @@ def _job_spec_fixtures() -> list[Path]:
     return fixtures
 
 
+def _neutralize_unsupported_regex(node):
+    """Recursively replace ``pattern`` regexes that Python's ``re`` cannot compile.
+
+    Newer Databricks CLIs emit ECMA-262 patterns (e.g. ``\\p{...}``) that Python's ``re``
+    module rejects with ``bad escape``, which crashes jsonschema when a matching string
+    field is validated. We validate structure (unknown fields, types, required, enums)
+    rather than string patterns, so an unparseable ``pattern`` is replaced with a permissive
+    ``".*"`` instead of being deleted.
+
+    We replace rather than delete because ``pattern`` discriminates ``oneOf`` branches in
+    the bundle schema (e.g. ``git_provider`` has a patterned-string branch and an enum
+    branch); deleting it would collapse the two into identical ``{"type": "string"}``
+    schemas and cause spurious ``oneOf`` failures.
+    """
+    if isinstance(node, dict):
+        return {
+            key: (_neutralized_pattern(value) if key == "pattern" else _neutralize_unsupported_regex(value))
+            for key, value in node.items()
+        }
+    if isinstance(node, list):
+        return [_neutralize_unsupported_regex(item) for item in node]
+    return node
+
+
+def _neutralized_pattern(value):
+    """Return the pattern unchanged if Python's ``re`` can compile it, else a permissive ``.*``."""
+    if not isinstance(value, str):
+        return value
+    try:
+        re.compile(value)
+    except re.error:
+        return ".*"
+    return value
+
+
 @pytest.fixture(scope="module")
 def bundle_validator() -> jsonschema.protocols.Validator:
     """Generate the DAB JSON schema via the Databricks CLI and build a validator."""
@@ -65,10 +101,11 @@ def bundle_validator() -> jsonschema.protocols.Validator:
         check=False,
     )
     assert result.returncode == 0, f"`databricks bundle schema` failed:\n{result.stderr}"
-    schema = json.loads(result.stdout)
-    validator_cls = jsonschema.validators.validator_for(schema)
-    validator_cls.check_schema(schema)
-    return validator_cls(schema)
+    schema = _neutralize_unsupported_regex(json.loads(result.stdout))
+    # The bundle schema declares no `$schema`. Draft 2020-12, which `validator_for` would
+    # pick by default, reports spurious `oneOf` failures on this schema; Draft 7 still
+    # resolves the nested `$ref`s and catches real errors (unknown fields, wrong types).
+    return jsonschema.Draft7Validator(schema)
 
 
 def test_test_data_fixtures_exist():

--- a/tests/integration/test_bundle_schema.py
+++ b/tests/integration/test_bundle_schema.py
@@ -27,18 +27,31 @@ import yaml
 
 TEST_DATA = Path(__file__).resolve().parent.parent / "test_data"
 
-_DATABRICKS_CLI = shutil.which("databricks")
 
-# In CI the Databricks CLI must be present (the workflow installs it), so a missing CLI is
-# a hard failure that surfaces a broken pipeline. Locally, where contributors may not have
-# the CLI, we skip with a clear reason instead of forcing everyone to install it.
-if _DATABRICKS_CLI is None:
+def _require_databricks_cli() -> str:
+    """Resolve the Databricks CLI, deciding fail-vs-skip based on the environment.
+
+    In CI the CLI must be present (the integration workflow installs it via
+    databricks/setup-cli), so a missing CLI is a hard failure that surfaces a broken
+    pipeline rather than a silent skip. Locally, where contributors may not have the CLI,
+    the tests skip with a clear reason instead of forcing everyone to install it.
+
+    This runs inside a fixture (not at import time) so that merely importing the module —
+    e.g. pylint's pytest plugin enumerating fixtures, or pytest collection in the build
+    workflow, which does not install the CLI — never trips the requirement.
+    """
+    cli = shutil.which("databricks")
+    if cli is not None:
+        return cli
+    message = (
+        "the 'databricks' CLI is required to generate the bundle schema but was not found "
+        "on PATH. The CI workflow must install it (databricks/setup-cli)."
+    )
+    # pytest.fail/skip raise, so this never falls through; the explicit raise keeps the
+    # control flow unambiguous for static analysis.
     if os.environ.get("CI"):
-        raise RuntimeError(
-            "the 'databricks' CLI is required to generate the bundle schema but was not "
-            "found on PATH. The CI workflow must install it (databricks/setup-cli)."
-        )
-    pytestmark = pytest.mark.skip(reason="databricks CLI not installed; skipping bundle schema validation locally")
+        raise pytest.fail.Exception(message)
+    raise pytest.skip.Exception(message)
 
 
 def _job_spec_fixtures() -> list[Path]:
@@ -104,9 +117,9 @@ def _translate_pattern(value):
 @pytest.fixture(scope="module")
 def bundle_validator() -> jsonschema.protocols.Validator:
     """Generate the DAB JSON schema via the Databricks CLI and build a validator."""
-    assert _DATABRICKS_CLI is not None  # guaranteed: CI raises above, local skips
+    cli = _require_databricks_cli()
     result = subprocess.run(  # noqa: S603
-        [_DATABRICKS_CLI, "bundle", "schema"],
+        [cli, "bundle", "schema"],
         capture_output=True,
         text=True,
         check=False,

--- a/tests/integration/test_bundle_schema.py
+++ b/tests/integration/test_bundle_schema.py
@@ -1,0 +1,89 @@
+"""Validate the committed ``tests/test_data`` job specs against the Databricks Asset
+Bundle (DAB) JSON schema.
+
+The unit and CLI tests prove the generator produces the output we *expect* (golden-file
+diffs), but nothing there proves that expected output is actually a spec Databricks would
+accept — a rename or typo could keep the golden files self-consistent yet emit an invalid
+bundle. This test closes that gap: it validates every fixture against the real bundle
+schema, so an invalid field or wrong type in a fixture (or in future generated output that
+we snapshot as a fixture) fails CI.
+
+The schema is produced on the fly with ``databricks bundle schema``, which runs fully
+offline (no workspace, no auth). We deliberately do not commit the schema to avoid a
+duplicated, drift-prone copy — CI installs the Databricks CLI and generates it fresh.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+
+TEST_DATA = Path(__file__).resolve().parent.parent / "test_data"
+
+_DATABRICKS_CLI = shutil.which("databricks")
+
+# In CI the Databricks CLI must be present (the workflow installs it), so a missing CLI is
+# a hard failure that surfaces a broken pipeline. Locally, where contributors may not have
+# the CLI, we skip with a clear reason instead of forcing everyone to install it.
+if _DATABRICKS_CLI is None:
+    if os.environ.get("CI"):
+        raise RuntimeError(
+            "the 'databricks' CLI is required to generate the bundle schema but was not "
+            "found on PATH. The CI workflow must install it (databricks/setup-cli)."
+        )
+    pytestmark = pytest.mark.skip(reason="databricks CLI not installed; skipping bundle schema validation locally")
+
+
+def _job_spec_fixtures() -> list[Path]:
+    """All test_data YAML fixtures that contain a `resources` block to validate.
+
+    The bare template (`job_definition_template.yaml`) is included too — it is a valid
+    partial bundle and should also conform to the schema.
+    """
+    fixtures = []
+    for path in sorted(TEST_DATA.glob("job_definition*.yaml")):
+        with open(path, "r", encoding="utf-8") as file:
+            content = yaml.safe_load(file)
+        if isinstance(content, dict) and "resources" in content:
+            fixtures.append(path)
+    return fixtures
+
+
+@pytest.fixture(scope="module")
+def bundle_validator() -> jsonschema.protocols.Validator:
+    """Generate the DAB JSON schema via the Databricks CLI and build a validator."""
+    assert _DATABRICKS_CLI is not None  # guaranteed: CI raises above, local skips
+    result = subprocess.run(  # noqa: S603
+        [_DATABRICKS_CLI, "bundle", "schema"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"`databricks bundle schema` failed:\n{result.stderr}"
+    schema = json.loads(result.stdout)
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator_cls.check_schema(schema)
+    return validator_cls(schema)
+
+
+def test_test_data_fixtures_exist():
+    """Guard against silently validating nothing if the fixtures move or are renamed."""
+    assert _job_spec_fixtures(), "expected at least one job_definition*.yaml fixture in tests/test_data"
+
+
+@pytest.mark.parametrize("fixture", _job_spec_fixtures(), ids=lambda p: p.name)
+def test_fixture_is_valid_dab(fixture, bundle_validator):
+    """Every committed job spec fixture conforms to the Databricks Asset Bundle schema."""
+    with open(fixture, "r", encoding="utf-8") as file:
+        spec = yaml.safe_load(file)
+
+    errors = sorted(bundle_validator.iter_errors(spec), key=lambda e: list(e.path))
+    assert not errors, "invalid DAB in {}:\n{}".format(
+        fixture.name,
+        "\n".join(f"  at {list(e.path)}: {e.message}" for e in errors),
+    )


### PR DESCRIPTION
Ensures the generated job specs in `tests/test_data` are valid Databricks Asset Bundles, not just self-consistent golden files.

## What

- Adds `tests/integration/test_bundle_schema.py` which validates every `tests/test_data` job spec against the DAB JSON schema. Golden-file tests prove the generator emits what we *expect*; this proves that expected output is a spec Databricks would actually accept (catches unknown fields, wrong types, etc.).
- The schema is **generated on the fly** with `databricks bundle schema` (runs fully offline — no workspace, no auth) rather than committed to the repo, to avoid a duplicated, drift-prone copy.
- CI installs the Databricks CLI via `databricks/setup-cli`. A missing CLI **fails loudly in CI** (`CI=true`) and **skips locally** so contributors are not forced to install the CLI.
- Adds `jsonschema` to dev dependencies and documents the CLI requirement in CONTRIBUTING.md.

## Why not `databricks bundle validate`?

`bundle validate` always calls the workspace (`scim/v2/Me`) and its exit code is dominated by that auth call, not by schema problems (which it only reports as warnings) — so it can't be a reliable offline CI gate. `bundle schema` + `jsonschema` gives deterministic, offline schema validation.

## Verification

`make lint` (10.00/10), `make test` (35 passed, 1 skipped), and `make integration` (12 passed: 4 CLI + 8 schema) all pass locally. Verified the fail-loud path raises (not skips) when the CLI is absent under `CI=true`.

This pull request and its description were written by Isaac.