### PR TITLE
Add offline end-to-end test of the documented example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,10 @@ make integration
 `make integration` builds the package and drives the installed `databricks_dbt_factory` CLI as a
 real subprocess against the fixtures in `tests/test_data`, comparing the generated job spec to the
 committed golden files. It also validates every fixture against the Databricks Asset Bundle schema
-(generated on the fly with `databricks bundle schema`) to ensure the generated specs are valid DABs.
-It requires no Databricks workspace and runs in CI alongside the unit tests.
+(generated on the fly with `databricks bundle schema`) to ensure the generated specs are valid DABs,
+and runs the [end-to-end example](README.md#end-to-end-example) offline — invoking the CLI with the
+documented arguments against the committed manifest and validating the freshly generated spec. It
+requires no Databricks workspace and runs in CI alongside the unit tests.
 
 The bundle-schema validation needs the [Databricks CLI](https://docs.databricks.com/dev-tools/cli/)
 on your `PATH`. If it is not installed those tests are skipped locally (but they are required and

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,105 @@
+"""Shared fixtures for the integration tests.
+
+The Databricks Asset Bundle (DAB) schema validator is defined here so multiple test
+modules (fixture validation and the end-to-end example) can reuse it without duplicating
+the CLI invocation or the schema-normalisation logic.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import warnings
+
+import jsonschema
+import pytest
+
+
+def require_databricks_cli() -> str:
+    """Resolve the Databricks CLI, deciding fail-vs-skip based on the environment.
+
+    In CI the CLI must be present (the integration workflow installs it via
+    databricks/setup-cli), so a missing CLI is a hard failure that surfaces a broken
+    pipeline rather than a silent skip. Locally, where contributors may not have the CLI,
+    the tests skip with a clear reason instead of forcing everyone to install it.
+
+    This runs inside a fixture (not at import time) so that merely importing a test module —
+    e.g. pylint's pytest plugin enumerating fixtures, or pytest collection in the build
+    workflow, which does not install the CLI — never trips the requirement.
+    """
+    cli = shutil.which("databricks")
+    if cli is not None:
+        return cli
+    message = (
+        "the 'databricks' CLI is required to generate the bundle schema but was not found "
+        "on PATH. The CI workflow must install it (databricks/setup-cli)."
+    )
+    # pytest.fail/skip raise, so this never falls through; the explicit raise keeps the
+    # control flow unambiguous for static analysis.
+    if os.environ.get("CI"):
+        raise pytest.fail.Exception(message)
+    raise pytest.skip.Exception(message)
+
+
+def _translate_pattern(value):
+    """Translate ECMA Unicode property escapes to Python-compatible character classes.
+
+    ``\\p{L}`` -> ``[^\\W\\d_]`` (any letter) and ``\\p{N}`` -> ``\\d`` (any digit). Falls
+    back to a permissive ``.*`` only if the result still cannot compile, so a genuinely
+    exotic future pattern degrades gracefully instead of crashing the suite.
+    """
+    if not isinstance(value, str):
+        return value
+    translated = value.replace(r"\p{L}", r"[^\W\d_]").replace(r"\p{N}", r"\d")
+    try:
+        with warnings.catch_warnings():
+            # Translating `[\p{L}\p{N}]` yields a nested set `[[^\W\d_]\d]`, which Python
+            # accepts but warns about; the pattern still means "letters or digits".
+            warnings.simplefilter("ignore", FutureWarning)
+            re.compile(translated)
+    except re.error:
+        return ".*"
+    return translated
+
+
+def _neutralize_unsupported_regex(node):
+    """Recursively rewrite ``pattern`` regexes that Python's ``re`` cannot compile.
+
+    The Databricks CLI emits ECMA-262 patterns using Unicode property escapes such as
+    ``\\p{L}`` (letters) and ``\\p{N}`` (numbers) — e.g. the ``${var.name}`` interpolation
+    pattern — which Python's ``re`` module rejects with ``bad escape``, crashing jsonschema
+    when a matching string field is validated. We translate those escapes to their Python
+    equivalents so the pattern still means the same thing.
+
+    We translate rather than delete or blanket-replace with ``.*`` because ``pattern``
+    discriminates ``oneOf`` branches (e.g. ``git_provider`` is *either* a known-provider
+    enum *or* a ``${var...}`` reference). Collapsing the pattern to ``.*`` would make a
+    literal like ``gitHub`` match both branches and cause a spurious ``oneOf`` failure.
+    """
+    if isinstance(node, dict):
+        return {
+            key: (_translate_pattern(value) if key == "pattern" else _neutralize_unsupported_regex(value))
+            for key, value in node.items()
+        }
+    if isinstance(node, list):
+        return [_neutralize_unsupported_regex(item) for item in node]
+    return node
+
+
+@pytest.fixture(scope="session")
+def bundle_validator() -> jsonschema.protocols.Validator:
+    """Generate the DAB JSON schema via the Databricks CLI and build a validator."""
+    cli = require_databricks_cli()
+    result = subprocess.run(  # noqa: S603
+        [cli, "bundle", "schema"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"`databricks bundle schema` failed:\n{result.stderr}"
+    schema = _neutralize_unsupported_regex(json.loads(result.stdout))
+    # The bundle schema declares no `$schema`. Draft 2020-12, which `validator_for` would
+    # pick by default, reports spurious `oneOf` failures on this schema; Draft 7 still
+    # resolves the nested `$ref`s and catches real errors (unknown fields, wrong types).
+    return jsonschema.Draft7Validator(schema)

--- a/tests/integration/test_bundle_schema.py
+++ b/tests/integration/test_bundle_schema.py
@@ -10,48 +10,16 @@ we snapshot as a fixture) fails CI.
 
 The schema is produced on the fly with ``databricks bundle schema``, which runs fully
 offline (no workspace, no auth). We deliberately do not commit the schema to avoid a
-duplicated, drift-prone copy — CI installs the Databricks CLI and generates it fresh.
+duplicated, drift-prone copy — CI installs the Databricks CLI and generates it fresh. See
+``conftest.py`` for the ``bundle_validator`` fixture.
 """
 
-import json
-import os
-import re
-import shutil
-import subprocess
-import warnings
 from pathlib import Path
 
-import jsonschema
 import pytest
 import yaml
 
 TEST_DATA = Path(__file__).resolve().parent.parent / "test_data"
-
-
-def _require_databricks_cli() -> str:
-    """Resolve the Databricks CLI, deciding fail-vs-skip based on the environment.
-
-    In CI the CLI must be present (the integration workflow installs it via
-    databricks/setup-cli), so a missing CLI is a hard failure that surfaces a broken
-    pipeline rather than a silent skip. Locally, where contributors may not have the CLI,
-    the tests skip with a clear reason instead of forcing everyone to install it.
-
-    This runs inside a fixture (not at import time) so that merely importing the module —
-    e.g. pylint's pytest plugin enumerating fixtures, or pytest collection in the build
-    workflow, which does not install the CLI — never trips the requirement.
-    """
-    cli = shutil.which("databricks")
-    if cli is not None:
-        return cli
-    message = (
-        "the 'databricks' CLI is required to generate the bundle schema but was not found "
-        "on PATH. The CI workflow must install it (databricks/setup-cli)."
-    )
-    # pytest.fail/skip raise, so this never falls through; the explicit raise keeps the
-    # control flow unambiguous for static analysis.
-    if os.environ.get("CI"):
-        raise pytest.fail.Exception(message)
-    raise pytest.skip.Exception(message)
 
 
 def _job_spec_fixtures() -> list[Path]:
@@ -67,69 +35,6 @@ def _job_spec_fixtures() -> list[Path]:
         if isinstance(content, dict) and "resources" in content:
             fixtures.append(path)
     return fixtures
-
-
-def _neutralize_unsupported_regex(node):
-    """Recursively rewrite ``pattern`` regexes that Python's ``re`` cannot compile.
-
-    The Databricks CLI emits ECMA-262 patterns using Unicode property escapes such as
-    ``\\p{L}`` (letters) and ``\\p{N}`` (numbers) — e.g. the ``${var.name}`` interpolation
-    pattern — which Python's ``re`` module rejects with ``bad escape``, crashing jsonschema
-    when a matching string field is validated. We translate those escapes to their Python
-    equivalents so the pattern still means the same thing.
-
-    We translate rather than delete or blanket-replace with ``.*`` because ``pattern``
-    discriminates ``oneOf`` branches (e.g. ``git_provider`` is *either* a known-provider
-    enum *or* a ``${var...}`` reference). Collapsing the pattern to ``.*`` would make a
-    literal like ``gitHub`` match both branches and cause a spurious ``oneOf`` failure.
-    """
-    if isinstance(node, dict):
-        return {
-            key: (_translate_pattern(value) if key == "pattern" else _neutralize_unsupported_regex(value))
-            for key, value in node.items()
-        }
-    if isinstance(node, list):
-        return [_neutralize_unsupported_regex(item) for item in node]
-    return node
-
-
-def _translate_pattern(value):
-    """Translate ECMA Unicode property escapes to Python-compatible character classes.
-
-    ``\\p{L}`` -> ``[^\\W\\d_]`` (any letter) and ``\\p{N}`` -> ``\\d`` (any digit). Falls
-    back to a permissive ``.*`` only if the result still cannot compile, so a genuinely
-    exotic future pattern degrades gracefully instead of crashing the suite.
-    """
-    if not isinstance(value, str):
-        return value
-    translated = value.replace(r"\p{L}", r"[^\W\d_]").replace(r"\p{N}", r"\d")
-    try:
-        with warnings.catch_warnings():
-            # Translating `[\p{L}\p{N}]` yields a nested set `[[^\W\d_]\d]`, which Python
-            # accepts but warns about; the pattern still means "letters or digits".
-            warnings.simplefilter("ignore", FutureWarning)
-            re.compile(translated)
-    except re.error:
-        return ".*"
-    return translated
-
-
-@pytest.fixture(scope="module")
-def bundle_validator() -> jsonschema.protocols.Validator:
-    """Generate the DAB JSON schema via the Databricks CLI and build a validator."""
-    cli = _require_databricks_cli()
-    result = subprocess.run(  # noqa: S603
-        [cli, "bundle", "schema"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert result.returncode == 0, f"`databricks bundle schema` failed:\n{result.stderr}"
-    schema = _neutralize_unsupported_regex(json.loads(result.stdout))
-    # The bundle schema declares no `$schema`. Draft 2020-12, which `validator_for` would
-    # pick by default, reports spurious `oneOf` failures on this schema; Draft 7 still
-    # resolves the nested `$ref`s and catches real errors (unknown fields, wrong types).
-    return jsonschema.Draft7Validator(schema)
 
 
 def test_test_data_fixtures_exist():

--- a/tests/integration/test_e2e_example.py
+++ b/tests/integration/test_e2e_example.py
@@ -69,7 +69,12 @@ def test_end_to_end_generates_valid_bundle(extra_args, description, bundle_valid
 
     Uses the same invocation documented in the README "End-to-end example" (step 5).
     """
-    target = tmp_path / "dbt_sql_job_explicit_tasks.yml"
+    # Place the spec under a `resources/` subdirectory, mirroring the demo project layout.
+    # This also keeps the notebook-mode runner copy — written relative to `--project-directory
+    # ../` — inside `tmp_path` rather than escaping to pytest's shared base temp dir.
+    resources_dir = tmp_path / "resources"
+    resources_dir.mkdir()
+    target = resources_dir / "dbt_sql_job_explicit_tasks.yml"
 
     _run_factory(target, *extra_args)
 
@@ -79,6 +84,13 @@ def test_end_to_end_generates_valid_bundle(extra_args, description, bundle_valid
 
     # The generated job is renamed via --new-job-name; confirm the CLI honoured it.
     assert "dbt_sql_job_explicit_tasks" in spec["resources"]["jobs"], "expected the renamed job in the generated spec"
+
+    # In notebook mode the packaged runner is copied to the computed project root
+    # (`../` from the spec, i.e. tmp_path) so `databricks bundle deploy` uploads it.
+    if "notebook" in extra_args:
+        runner = tmp_path / "run_dbt_command.py"
+        assert runner.exists(), "notebook mode should copy the runner notebook to the project root"
+        assert "dbtRunner" in runner.read_text(encoding="utf-8"), "copied file should be the packaged runner"
 
     errors = sorted(bundle_validator.iter_errors(spec), key=lambda e: list(e.path))
     assert not errors, "generated spec ({}) is not a valid DAB:\n{}".format(

--- a/tests/integration/test_e2e_example.py
+++ b/tests/integration/test_e2e_example.py
@@ -1,0 +1,84 @@
+"""End-to-end test of the documented example, without a live Databricks workspace.
+
+The project README walks through an end-to-end flow against the companion
+`mwojtyczka/dbt-demo` project: compile the dbt project to a manifest, run the factory CLI
+to generate a Databricks Workflow spec, then deploy and run it. The only steps that need a
+live workspace are `dbt compile` (which needs a warehouse connection) and the final
+deploy/run. Everything in between is offline.
+
+This test exercises that offline middle: it runs the installed `databricks_dbt_factory`
+CLI with the *same arguments the README documents* (step 5 of the "End-to-end example"),
+using the committed dbt manifest — which is itself the frozen output of `dbt compile` on
+the demo project — and then validates the freshly generated spec against the real DAB
+schema. It deliberately does not clone dbt-demo: the manifest fixture captures that
+external dependency's output, so the test stays hermetic and offline.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+TEST_DATA = Path(__file__).resolve().parent.parent / "test_data"
+
+CLI = shutil.which("databricks_dbt_factory")
+
+
+def _run_factory(target_path: Path, *extra_args: str) -> None:
+    """Run the factory CLI with the README end-to-end example arguments."""
+    assert CLI is not None, "databricks_dbt_factory console script must be installed (run via `make integration`)"
+    result = subprocess.run(  # noqa: S603
+        [
+            CLI,
+            "--dbt-manifest-path",
+            str(TEST_DATA / "manifest.json"),
+            "--input-job-spec-path",
+            str(TEST_DATA / "job_definition_template.yaml"),
+            "--target-job-spec-path",
+            str(target_path),
+            "--target",
+            "${bundle.target}",
+            "--project-directory",
+            "../",
+            "--profiles-directory",
+            ".",
+            "--environment-key",
+            "Default",
+            "--new-job-name",
+            "dbt_sql_job_explicit_tasks",
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"factory CLI failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+
+@pytest.mark.parametrize(
+    "extra_args, description",
+    [
+        pytest.param((), "dbt task type", id="dbt-task"),
+        pytest.param(("--task-type", "notebook"), "notebook task type", id="notebook-task"),
+    ],
+)
+def test_readme_example_generates_valid_bundle(extra_args, description, bundle_validator, tmp_path):
+    """The documented end-to-end command produces a spec that is a valid Databricks bundle."""
+    target = tmp_path / "dbt_sql_job_explicit_tasks.yml"
+
+    _run_factory(target, *extra_args)
+
+    assert target.exists(), f"factory did not write the target spec for {description}"
+    with open(target, "r", encoding="utf-8") as file:
+        spec = yaml.safe_load(file)
+
+    # The generated job is renamed via --new-job-name; confirm the CLI honoured it.
+    assert "dbt_sql_job_explicit_tasks" in spec["resources"]["jobs"], "expected the renamed job in the generated spec"
+
+    errors = sorted(bundle_validator.iter_errors(spec), key=lambda e: list(e.path))
+    assert not errors, "generated spec ({}) is not a valid DAB:\n{}".format(
+        description,
+        "\n".join(f"  at {list(e.path)}: {e.message}" for e in errors),
+    )

--- a/tests/integration/test_e2e_example.py
+++ b/tests/integration/test_e2e_example.py
@@ -64,8 +64,11 @@ def _run_factory(target_path: Path, *extra_args: str) -> None:
         pytest.param(("--task-type", "notebook"), "notebook task type", id="notebook-task"),
     ],
 )
-def test_readme_example_generates_valid_bundle(extra_args, description, bundle_validator, tmp_path):
-    """The documented end-to-end command produces a spec that is a valid Databricks bundle."""
+def test_end_to_end_generates_valid_bundle(extra_args, description, bundle_validator, tmp_path):
+    """The end-to-end command produces a spec that is a valid Databricks bundle.
+
+    Uses the same invocation documented in the README "End-to-end example" (step 5).
+    """
     target = tmp_path / "dbt_sql_job_explicit_tasks.yml"
 
     _run_factory(target, *extra_args)


### PR DESCRIPTION
Adds an offline end-to-end test covering the README's [End-to-end example](https://github.com/mwojtyczka/databricks-dbt-factory#end-to-end-example), without depending on the companion `dbt-demo` repo or a live workspace.

## What

- Adds `tests/integration/test_e2e_example.py`, which runs the installed `databricks_dbt_factory` CLI with the **same arguments the README documents** (step 5), for both dbt and notebook task types, then validates the freshly generated spec against the real DAB schema.
- Uses the committed `tests/test_data/manifest.json` — itself the frozen output of `dbt compile` on the demo project — so the test stays hermetic. It deliberately does **not** clone `dbt-demo`: the manifest fixture captures that external dependency's output. (`dbt compile` and deploy/run are the only steps needing a live workspace, and remain manual.)
- Moves the `bundle_validator` fixture and schema-normalisation helpers into `tests/integration/conftest.py` so the fixture-validation and e2e tests share them without duplication.

## Why no cross-repo dependency

The concern was depending on another repo. `dbt compile` needs a live Databricks connection, so cloning `dbt-demo` couldn't run offline anyway. Capturing its compiled manifest as a fixture is the right pattern — the offline portion of the e2e (manifest → generate → validate) runs with zero external dependency.

## Verification

`make integration` (14 passed: 4 CLI + 8 schema + 2 e2e), `make lint` (10.00/10), `make test` (35 passed, 1 skipped) all pass locally against the v1.8.0 Databricks CLI (the version CI installs).

This pull request and its description were written by Isaac.