### PR TITLE
Add --version flag and document upgrading the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It reads your dbt manifest and generates a new job specification — a Databrick
 - [How it works](#how-it-works)
 - [Installation](#installation)
 - [Usage](#usage)
-- [dbt test handling](#dbt-test-handling)
+- [Handling dbt tests](#handling-dbt-tests)
 - [Task types](#task-types)
 - [End-to-end example](#end-to-end-example)
 - [Contribution](#contribution)
@@ -316,11 +316,11 @@ databricks_dbt_factory  \
 - `--job-cluster-key` (type: str, optional): Job cluster key for running tasks on job compute instead of serverless. Mutually exclusive with `--environment-key`.
 - `--extra-dbt-command-options` (type: str, optional, default: ""): Additional dbt command options to include.
 - `--no-run-tests` (flag, default: tests enabled): Skip generating dbt test tasks. Tests are included by default.
-- `--bundle-tests` (flag, default: disabled): **Performance boost** — bundle single-model tests per resource into one `dbt test --select <resource>` task. Fewer Databricks tasks means fewer task startups, fewer dbt cold starts, and noticeably faster end-to-end runtime for projects with many tests. Downstream models/seeds/snapshots gate on the upstream's `<resource>_test` task so failing tests still halt the DAG. Cross-model tests are emitted as their own tasks with multi-resource deps. See [dbt test handling](#dbt-test-handling).
+- `--bundle-tests` (flag, default: disabled): **Performance boost** — bundle single-model tests per resource into one `dbt test --select <resource>` task. Fewer Databricks tasks means fewer task startups, fewer dbt cold starts, and noticeably faster end-to-end runtime for projects with many tests. Downstream models/seeds/snapshots gate on the upstream's `<resource>_test` task so failing tests still halt the DAG. Cross-model tests are emitted as their own tasks with multi-resource deps. See [Handling dbt tests](#handling-dbt-tests).
 - `--enable-dbt-deps` (flag, default: disabled): Run `dbt deps` before each task.
 - `--dbt-tasks-deps` (type: str, optional, default: None): Comma separated list of tasks for which dbt deps should be run (e.g. "diamonds_prices,second_dbt_model"). Only in effect if `--enable-dbt-deps` is set.
 - `--dry-run` (flag, default: disabled): Print generated tasks without updating the job spec file.
-- `--version` (flag): Print the installed `databricks-dbt-factory` version and exit.
+- `--version` (flag): Print the installed `databricks-dbt-factory` version.
 
 You can also check all input arguments by running `databricks_dbt_factory --help`.
 
@@ -343,7 +343,7 @@ dbt's test hash (e.g. `pkg_a_customers_model` / `pkg_b_customers_model`). Keys a
 unique, so a valid dbt project can never fail to deploy on a duplicate task key. Keys are also
 bounded to Databricks' 100-character limit (long test names are truncated with a hash suffix).
 
-## dbt test handling
+## Handling dbt tests
 
 The factory produces tasks for dbt tests (both data tests and unit tests) from the manifest by
 default (pass `--no-run-tests` to skip them). Selectors use each node's full dot-separated FQN

--- a/README.md
+++ b/README.md
@@ -153,7 +153,29 @@ flowchart LR
 pip install databricks-dbt-factory
 ```
 
-> **For production, pin the version** to get reproducible builds and avoid unexpected changes from new releases, e.g. `pip install databricks-dbt-factory==0.2.2`.
+> **For production, pin the version** to get reproducible builds and avoid unexpected changes from new releases, e.g. `pip install databricks-dbt-factory==0.3.1`.
+
+Check the installed version at any time:
+
+```shell
+databricks_dbt_factory --version
+```
+
+## Upgrading
+
+Upgrade to the latest release:
+
+```shell
+pip install --upgrade databricks-dbt-factory
+```
+
+Or pin to a specific version (recommended for production):
+
+```shell
+pip install --upgrade databricks-dbt-factory==<version>
+```
+
+Run `databricks_dbt_factory --version` afterwards to confirm the upgrade.
 
 # Usage
 
@@ -298,6 +320,7 @@ databricks_dbt_factory  \
 - `--enable-dbt-deps` (flag, default: disabled): Run `dbt deps` before each task.
 - `--dbt-tasks-deps` (type: str, optional, default: None): Comma separated list of tasks for which dbt deps should be run (e.g. "diamonds_prices,second_dbt_model"). Only in effect if `--enable-dbt-deps` is set.
 - `--dry-run` (flag, default: disabled): Print generated tasks without updating the job spec file.
+- `--version` (flag): Print the installed `databricks-dbt-factory` version and exit.
 
 You can also check all input arguments by running `databricks_dbt_factory --help`.
 

--- a/src/databricks_dbt_factory/main.py
+++ b/src/databricks_dbt_factory/main.py
@@ -215,7 +215,7 @@ def parse_args():
             "tests. Cross-model tests (e.g. `relationships`) are detected from the manifest and "
             "emitted as their own tasks gated on every referenced resource, so no tests are "
             "silently dropped. Trade-off: fewer tasks and a smaller DAG, but per-test failures "
-            "show up as a single red `<resource>_tests` task — drill into the logs to see which "
+            "show up as a single red `<resource>_test` task — drill into the logs to see which "
             "assertion failed."
         ),
     )

--- a/src/databricks_dbt_factory/main.py
+++ b/src/databricks_dbt_factory/main.py
@@ -4,6 +4,7 @@ import shutil
 from importlib import resources
 from pathlib import Path
 
+from databricks_dbt_factory.__about__ import __version__
 from databricks_dbt_factory.DbtFactory import DbtFactory
 from databricks_dbt_factory.job_spec import replace_tasks_in_job_spec
 from databricks_dbt_factory.Utils import read_dbt_manifest
@@ -136,6 +137,12 @@ def build_dbt_options(args):
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Generate Databricks job definition from dbt manifest.")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"databricks-dbt-factory {__version__}",
+        help="Show the installed databricks-dbt-factory version and exit.",
+    )
     parser.add_argument(
         "--new-job-name",
         type=str,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from databricks_dbt_factory.__about__ import __version__
 from databricks_dbt_factory.main import main, parse_args
 
 BASE_PATH = str(Path(__file__).resolve().parent)
@@ -286,6 +287,16 @@ REQUIRED_ARGS = [
     "--target-job-spec-path",
     "out.yaml",
 ]
+
+
+def test_version_flag_prints_version_and_exits(monkeypatch, capsys):
+    # --version short-circuits argparse (exits 0) before the required args are enforced.
+    monkeypatch.setattr("sys.argv", ["main.py", "--version"])
+    with pytest.raises(SystemExit) as exc:
+        parse_args()
+
+    assert exc.value.code == 0
+    assert __version__ in capsys.readouterr().out
 
 
 def test_explicit_environment_key_with_job_cluster_key_is_rejected(monkeypatch):


### PR DESCRIPTION
## What

- **`--version` flag** — `databricks_dbt_factory --version` prints the installed package version (e.g. `databricks-dbt-factory 0.3.1`) and exits. Implemented via argparse's `version` action, so it short-circuits before the otherwise-required args (`--dbt-manifest-path` etc.) are enforced.
- **README** — documents `--version` for checking the installed version, adds an **Upgrading** section (`pip install --upgrade`, plus version pinning for production), and lists `--version` under Arguments. Bumps the version-pin example to the current release.

## Why

There was no way to check the installed CLI version — the CLI had no `--version` flag, and `--help` didn't surface it. Users had to fall back to `pip show databricks-dbt-factory`. This adds the standard flag and documents the upgrade path.

## Testing

- New `test_version_flag_prints_version_and_exits` asserts `--version` exits 0 and prints the version, without requiring the mandatory args.
- `make test` (72 passed), `make integration` (14 passed), lint 10.00/10.

This pull request and its description were written by Isaac.