### PR TITLE
Fix notebook runner host/isolation and default task_type to notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ dbt manifest and its dependencies.
 
 ## dbt tasks
 
-With the default task type, each dbt object becomes a native Databricks `dbt_task`:
+With `--task-type dbt`, each dbt object becomes a native Databricks `dbt_task`:
 
 ```mermaid
 flowchart LR
@@ -117,9 +117,9 @@ flowchart LR
     class snap1 snapshot
 ```
 
-## Notebook runner tasks (recommended for best performance)
+## Notebook runner tasks (default, recommended for best performance)
 
-With `--task-type notebook`, each task instead runs the packaged runner notebook
+With the default task type, each task runs the packaged runner notebook
 (`run_dbt_command.py`), which triggers the dbt commands programmatically using dbt core package. This gives much faster task
 start times — see [Generating notebook tasks](#generating-notebook-tasks-within-databricks-workflows-recommended-for-best-performance).
 
@@ -220,6 +220,7 @@ databricks_dbt_factory  \
   --dbt-manifest-path target/manifest.json \
   --input-job-spec-path job_template.yaml \
   --target-job-spec-path job_definition.yaml \
+  --task-type dbt \
   --source GIT \
   --target dev
 ```
@@ -305,7 +306,7 @@ databricks_dbt_factory  \
 - `--target-job-spec-path` (type: str, required): Path to the target job spec file.
 - `--target` (type: str, optional): dbt target to use. If not provided, the default target from the dbt profile will be used.
 - `--source` (type: str, optional, default: None): Project source (`GIT` or `WORKSPACE`). If not provided, `WORKSPACE` will be used.
-- `--task-type` (type: str, optional, default: "dbt"): Task type to generate — `dbt` for native dbt_task, `notebook` for notebook_task wrapper.
+- `--task-type` (type: str, optional, default: "notebook"): Task type to generate — `notebook` for notebook_task wrapper, `dbt` for native dbt_task.
 - `--notebook-path` (type: str, optional): Path to the dbt runner notebook used when `--task-type notebook`. If omitted, the packaged runner notebook is copied next to the generated job spec and referenced relatively, so `databricks bundle deploy` uploads it automatically. **When provided, also pass `--project-directory` as an absolute workspace path** — see the note in [Generating notebook tasks](#generating-notebook-tasks-within-databricks-workflows-recommended-for-best-performance).
 - `--warehouse_id` (type: str, optional): SQL Warehouse ID. Only used with native dbt_task.
 - `--schema` (type: str, optional): Metastore schema. Only used with native dbt_task.
@@ -424,7 +425,7 @@ filtering.
 
 The factory supports two task types, controlled by `--task-type`:
 
-### `dbt` (default)
+### `dbt`
 
 Generates native Databricks `dbt_task` entries. This is the standard approach that
 uses Databricks' built-in dbt integration. Works with both classic compute and serverless.
@@ -432,7 +433,7 @@ uses Databricks' built-in dbt integration. Works with both classic compute and s
 **Limitations on Serverless:** Native dbt tasks do not support workspace base environments (requiring installing dependencies on every task)
 or environment variables. If you need either of these, use the `notebook` task type instead.
 
-### `notebook`
+### `notebook` (default)
 
 Generates `notebook_task` entries that wrap dbt execution via the `dbtRunner` Python API.
 Each task calls a shared runner notebook (`run_dbt_command.py`) with parameterized dbt commands.
@@ -522,7 +523,7 @@ The steps below walk through running it end-to-end.
       --new-job-name dbt_sql_job_explicit_tasks
     ```
 
-    For best performance, add `--task-type notebook` to the command above — it routes dbt execution through the packaged runner notebook (pre-cached base environments, faster cold starts). See [Generating notebook tasks](#generating-notebook-tasks-within-databricks-workflows-recommended-for-best-performance) for the full rationale.
+    This uses the default `notebook` task type, which routes dbt execution through the packaged runner notebook (pre-cached base environments, faster cold starts). See [Generating notebook tasks](#generating-notebook-tasks-within-databricks-workflows-recommended-for-best-performance) for the full rationale, or pass `--task-type dbt` for native dbt tasks.
 
 6. **Authenticate the Databricks CLI to your workspace.** The `databricks.yml` in the demo references a specific profile (e.g. `FIELD-ENG`) under each target. Log in so that profile resolves:
 

--- a/src/databricks_dbt_factory/DbtTask.py
+++ b/src/databricks_dbt_factory/DbtTask.py
@@ -53,10 +53,11 @@ class DbtTaskOptions:
     dbt_tasks_deps: list[str] = field(default_factory=list)
     """Optional comma separated list of tasks that requires dbt debs. Only in effect if dbt_deps_enabled is enabled."""
 
-    task_type: TaskType = TaskType.DBT
-    """Task type to generate: `TaskType.DBT` for native dbt_task, `TaskType.NOTEBOOK` for notebook_task
-    wrapper. Strings are accepted and coerced — any value outside the enum raises `ValueError`.
-    Notebook mode enables base environment support and environment variables on serverless."""
+    task_type: TaskType = TaskType.NOTEBOOK
+    """Task type to generate: `TaskType.NOTEBOOK` for a notebook_task wrapper (default),
+    `TaskType.DBT` for a native dbt_task. Strings are accepted and coerced — any value outside the
+    enum raises `ValueError`. Notebook mode enables base environment support and environment
+    variables on serverless."""
 
     notebook_path: str | None = None
     """Path to the dbt runner notebook. Required when task_type is `TaskType.NOTEBOOK`."""
@@ -68,6 +69,8 @@ class DbtTaskOptions:
         if not isinstance(self.task_type, TaskType):
             object.__setattr__(self, 'task_type', TaskType(self.task_type))
         if self.task_type is TaskType.NOTEBOOK:
+            if not self.notebook_path:
+                raise ValueError("notebook_path is required when task_type=NOTEBOOK.")
             unsupported = []
             for name, value in (
                 ('warehouse_id', self.warehouse_id),

--- a/src/databricks_dbt_factory/main.py
+++ b/src/databricks_dbt_factory/main.py
@@ -234,9 +234,9 @@ def parse_args():
     parser.add_argument(
         "--task-type",
         type=str,
-        help="Task type to generate: 'dbt' for native dbt_task (default), 'notebook' for notebook_task wrapper.",
+        help="Task type to generate: 'notebook' for notebook_task wrapper (default), 'dbt' for native dbt_task.",
         required=False,
-        default="dbt",
+        default="notebook",
         choices=["dbt", "notebook"],
     )
     parser.add_argument(

--- a/src/databricks_dbt_factory/notebook/run_dbt_command.py
+++ b/src/databricks_dbt_factory/notebook/run_dbt_command.py
@@ -25,7 +25,8 @@ if not dbt_commands:
 
 ctx = dbutils.notebook.entry_point.getDbutils().notebook().getContext()
 os.environ["DBT_ACCESS_TOKEN"] = ctx.apiToken().get()
-os.environ["DBT_HOST"] = ctx.apiUrl().get()
+# dbt's host must be a bare hostname; apiUrl() includes the https:// scheme.
+os.environ["DBT_HOST"] = ctx.apiUrl().get().removeprefix("https://").removeprefix("http://")
 
 # chdir to the dbt project so dbt runs from inside it. Relative `project_directory` is
 # resolved against this notebook's own workspace location — the same anchor native
@@ -42,17 +43,16 @@ if project_directory:
     )
     os.chdir(target_dir)
 
-# dbt writes `logs/dbt.log` and `target/` inside CWD on every run. DAB sync only uploads
-# files, not empty directories — pre-create them (idempotent).
-os.makedirs("logs", exist_ok=True)
-os.makedirs("target", exist_ok=True)
+# Point dbt's artifact and log output at a private per-task dir so the parallel tasks of a job
+# don't contend on the shared workspace `target/`/`logs/`.
+local_dir = tempfile.mkdtemp(prefix="dbt_local_")
+os.environ["DBT_TARGET_PATH"] = local_dir
+os.environ["DBT_LOG_PATH"] = local_dir
 
 # If a pre-built msgpack sits next to the project, deserialize it into a manifest and inject it into
-# dbtRunner to skip dbt's parse phase (re-reading/hashing every file + DAG rebuild) on each task. Each
-# task then writes artifacts to a private local dir (DBT_TARGET_PATH/DBT_LOG_PATH) to avoid contention
-# on the shared workspace `target/`. Falls back to a normal parse if the msgpack is absent or unusable.
+# dbtRunner to skip dbt's parse phase (re-reading/hashing every file + DAG rebuild) on each task.
+# Falls back to a normal parse if the msgpack is absent or unusable.
 manifest = None
-local_dir = None
 prebuilt_manifest_path = os.path.join("target", "partial_parse.msgpack")
 if os.path.exists(prebuilt_manifest_path):
     try:
@@ -61,9 +61,6 @@ if os.path.exists(prebuilt_manifest_path):
         with open(prebuilt_manifest_path, "rb") as f:
             manifest = Manifest.from_msgpack(f.read())
         manifest.build_flat_graph()
-        local_dir = tempfile.mkdtemp(prefix="dbt_local_")
-        os.environ["DBT_TARGET_PATH"] = local_dir
-        os.environ["DBT_LOG_PATH"] = local_dir
         print(f"[dbt-factory] injecting pre-built manifest from {prebuilt_manifest_path} (skipping dbt parse)")
     except Exception as e:
         print(f"[dbt-factory] manifest injection unavailable, falling back to dbt parse: {e}")

--- a/src/databricks_dbt_factory/notebook/run_dbt_command.py
+++ b/src/databricks_dbt_factory/notebook/run_dbt_command.py
@@ -5,6 +5,7 @@ import os
 import shlex
 import shutil
 import tempfile
+from urllib.parse import urlparse
 
 from dbt.cli.main import dbtRunner
 
@@ -25,8 +26,12 @@ if not dbt_commands:
 
 ctx = dbutils.notebook.entry_point.getDbutils().notebook().getContext()
 os.environ["DBT_ACCESS_TOKEN"] = ctx.apiToken().get()
-# dbt's host must be a bare hostname; apiUrl() includes the https:// scheme.
-os.environ["DBT_HOST"] = ctx.apiUrl().get().removeprefix("https://").removeprefix("http://")
+# dbt's host must be a bare hostname, but apiUrl() returns a full URL (scheme + host, and
+# potentially a trailing slash or path). Parse it and keep only the netloc so a value like
+# "https://my-workspace.databricks.com/" yields "my-workspace.databricks.com".
+_api_url = ctx.apiUrl().get()
+_parsed = urlparse(_api_url)
+os.environ["DBT_HOST"] = _parsed.netloc or _parsed.path.strip("/")
 
 # chdir to the dbt project so dbt runs from inside it. Relative `project_directory` is
 # resolved against this notebook's own workspace location — the same anchor native

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -65,8 +65,8 @@ def _load(path: Path) -> dict:
         return yaml.safe_load(file)
 
 
-def test_cli_default_args_matches_golden_spec(tmp_path):
-    """The installed CLI generates the expected default job spec from test_data."""
+def test_cli_dbt_task_matches_golden_spec(tmp_path):
+    """The installed CLI generates the expected native dbt_task job spec from test_data."""
     target = tmp_path / "job_definition.yaml"
 
     _run_cli(
@@ -76,6 +76,8 @@ def test_cli_default_args_matches_golden_spec(tmp_path):
         str(TEST_DATA / "job_definition_template.yaml"),
         "--target-job-spec-path",
         str(target),
+        "--task-type",
+        "dbt",
     )
 
     assert _load(target) == _load(TEST_DATA / "job_definition_default.yaml")

--- a/tests/integration/test_e2e_example.py
+++ b/tests/integration/test_e2e_example.py
@@ -60,7 +60,7 @@ def _run_factory(target_path: Path, *extra_args: str) -> None:
 @pytest.mark.parametrize(
     "extra_args, description",
     [
-        pytest.param((), "dbt task type", id="dbt-task"),
+        pytest.param(("--task-type", "dbt"), "dbt task type", id="dbt-task"),
         pytest.param(("--task-type", "notebook"), "notebook task type", id="notebook-task"),
     ],
 )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -10,8 +10,8 @@ from databricks_dbt_factory.main import main, parse_args
 BASE_PATH = str(Path(__file__).resolve().parent)
 
 
-def test_main_given_default_args(monkeypatch):
-    """Test the main function for job spec generation."""
+def test_main_dbt_task_type(monkeypatch):
+    """Test the main function generating native dbt_task specs."""
     dbt_manifest_path = BASE_PATH + "/test_data/manifest.json"
     input_job_spec_path = BASE_PATH + "/test_data/job_definition_template.yaml"
     expected_job_definition_path = BASE_PATH + "/test_data/job_definition_default.yaml"
@@ -29,6 +29,8 @@ def test_main_given_default_args(monkeypatch):
             input_job_spec_path,
             "--target-job-spec-path",
             target_job_spec_path,
+            "--task-type",
+            "dbt",
         ],
     )
 
@@ -250,6 +252,8 @@ def test_main_all_args(monkeypatch):
             project_dir,
             "--extra-dbt-command-options",
             extra_dbt_command_options,
+            "--task-type",
+            "dbt",
         ],
     )
 
@@ -329,6 +333,7 @@ def test_boolean_flags_default(monkeypatch):
     assert args.bundle_tests is False
     assert args.enable_dbt_deps is False
     assert args.dry_run is False
+    assert args.task_type == "notebook"
 
 
 def test_boolean_flags_toggled(monkeypatch):

--- a/tests/test_dbt_task.py
+++ b/tests/test_dbt_task.py
@@ -44,7 +44,7 @@ def test_notebook_task_without_job_cluster_key_uses_environment():
 
 
 def test_dbt_task_without_job_cluster_key_uses_environment():
-    options = DbtTaskOptions(environment_key="Default")
+    options = DbtTaskOptions(environment_key="Default", task_type=TaskType.DBT)
     task = DbtTask(task_key="my_model", commands=["dbt run --select my_model"], options=options)
 
     result = task.to_dict()
@@ -94,3 +94,12 @@ def test_dbt_task_still_accepts_warehouse_schema_catalog():
         catalog="main",
     )
     assert options.warehouse_id == "wh123"
+
+
+def test_task_type_defaults_to_notebook():
+    assert DbtTaskOptions(notebook_path="./runner.py").task_type is TaskType.NOTEBOOK
+
+
+def test_notebook_task_requires_notebook_path():
+    with pytest.raises(ValueError, match="notebook_path is required"):
+        DbtTaskOptions(task_type=TaskType.NOTEBOOK)


### PR DESCRIPTION
## What this does

Two changes to the notebook runner and the default task type, surfaced while vendoring the
library into the bundle-examples dbt-factory example.

### Notebook runner fixes (runtime bugs)

`src/databricks_dbt_factory/notebook/run_dbt_command.py`:

- **`DBT_HOST` scheme stripping.** `apiUrl()` returns `https://<workspace>`, but dbt-databricks
  needs a bare hostname (profiles.yml feeds `host:` verbatim). Without stripping, every dbt task
  fails to connect. Restored `.removeprefix("https://").removeprefix("http://")`.
- **Unconditional per-task target/log isolation.** `DBT_TARGET_PATH`/`DBT_LOG_PATH` (a private
  temp dir per task, so the parallel tasks of a job don't contend on the shared workspace
  `target/`/`logs/`) were set only inside `if os.path.exists(prebuilt_manifest_path)`. That
  msgpack is gitignored and never deployed, so isolation never actually applied at runtime. Now
  set unconditionally. Removed the now-dead `os.makedirs("logs"/"target")` (output goes to the
  private dir).

### Default task type → notebook (breaking)

`DbtTaskOptions.task_type` and the CLI `--task-type` now default to **`notebook`** (was `dbt`),
aligning the library, the CLI, and the downstream bundle on the notebook runner. `NOTEBOOK` now
also requires `notebook_path` (a missing path previously produced a silent `notebook_path: null`
malformed spec).

**Migration:** callers that want native `dbt_task` must pass `task_type=TaskType.DBT` (or
`--task-type dbt`). A bare `DbtTaskOptions()` now raises (notebook needs a `notebook_path`). The
CLI supplies one automatically by copying the packaged runner.

## Verification

- Unit tests: 74 passed. Integration: 14 passed. `make fmt`/lint: black, ruff, mypy, pylint 10/10.
- New tests: default-is-notebook (dataclass + CLI arg), NOTEBOOK-requires-notebook_path. dbt-mode
  tests/examples made explicit (`--task-type dbt`), including the integration golden-spec and e2e
  cases.

Suggest cutting this as a minor release and calling out the `task_type` default change in the
release notes.
