### PR TITLE
chore: adopt `ruff format` (double quotes) in place of black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ packages = ["src/databricks_dbt_factory"]
 
 [tool.hatch.envs.default]
 dependencies = [
-  "black~=24.3.0",
   "coverage[toml]~=7.4.4",
   "databricks-labs-pylint~=0.5",
   "jsonschema~=4.21",
@@ -63,7 +62,7 @@ dependencies = [
   "pytest-mock~=3.14.0",
   "pytest-timeout~=2.3.1",
   "pytest-xdist~=3.5.0",
-  "ruff~=0.3.4",
+  "ruff~=0.12.0",
   # dbt itself, so tests/integration/test_selector_against_dbt.py can verify every generated
   # `--select` against the real matcher instead of against our model of it. Not a runtime
   # dependency: the factory only reads a manifest dbt has already produced.
@@ -85,11 +84,11 @@ path = ".venv"
 test        = "pytest -n 10 src --timeout 30 --ignore=tests/integration tests --durations 20"
 integration = "pytest -n 10 --timeout 300 tests/integration --durations 20"
 coverage    = "pytest -n 10 --cov src tests/ --timeout 300 --cov-report=html --durations 20"
-fmt         = ["black .",
+fmt         = ["ruff format .",
                "ruff check . --fix",
                "mypy .",
                "pylint --output-format=colorized -j 0 src tests"]
-verify      = ["black --check .",
+verify      = ["ruff format --check .",
                "ruff check .",
                "mypy .",
                "pylint --output-format=colorized -j 0 src tests"]
@@ -105,16 +104,6 @@ ignore_missing_imports = true
 addopts = "--no-header"
 cache_dir = ".venv/pytest-cache"
 filterwarnings = ["ignore::DeprecationWarning"]
-
-[tool.black]
-target-version = ["py310"]
-line-length = 120
-skip-string-normalization = true
-extend-exclude = '''
-/(
-  src/databricks_dbt_factory/notebook
-)/
-'''
 
 [tool.ruff]
 cache-dir = ".venv/ruff-cache"

--- a/src/databricks_dbt_factory/DbtFactory.py
+++ b/src/databricks_dbt_factory/DbtFactory.py
@@ -9,7 +9,7 @@ from databricks_dbt_factory.TaskFactory import TaskFactory, TestTaskFactory
 from databricks_dbt_factory.Utils import DYNAMIC_VALUE_REFERENCE, build_task_key_maps
 
 # The `unique_id` prefixes of resources a test can be attached to.
-_DBT_TEST_TARGET_PREFIXES = ('model.', 'seed.', 'snapshot.', 'source.')
+_DBT_TEST_TARGET_PREFIXES = ("model.", "seed.", "snapshot.", "source.")
 
 
 def _flatten_fqn(fqn: list[str]) -> list[str]:
@@ -20,7 +20,7 @@ def _flatten_fqn(fqn: list[str]) -> list[str]:
     `check.nested` with fqn `['probe', 'check.nested']` compares as `['probe', 'check', 'nested']` —
     which is why the shorter `probe.check` matches it as a subtree parent.
     """
-    return [part for segment in fqn for part in segment.split('.')]
+    return [part for segment in fqn for part in segment.split(".")]
 
 
 @dataclass
@@ -68,7 +68,7 @@ def _base_file_name(original_file_path: str) -> str:
     selector terms must prove exactness or generation refuses the resource.
     """
     candidates = _candidate_file_names(original_file_path)
-    return next(iter(candidates)) if len(candidates) == 1 else ''
+    return next(iter(candidates)) if len(candidates) == 1 else ""
 
 
 class DbtFactory:
@@ -111,12 +111,12 @@ class DbtFactory:
         tasks = self._create_tasks(dbt_manifest)
         if len(tasks) > 1_000:
             raise ValueError(
-                f'Databricks jobs support at most 1,000 tasks; this manifest generates {len(tasks):,}. '
-                f'Reduce the generated resources or enable test bundling.'
+                f"Databricks jobs support at most 1,000 tasks; this manifest generates {len(tasks):,}. "
+                f"Reduce the generated resources or enable test bundling."
             )
         return [task.to_dict() for task in tasks]
 
-    _GATEABLE_TYPES = frozenset({'model', 'seed', 'snapshot'})
+    _GATEABLE_TYPES = frozenset({"model", "seed", "snapshot"})
     _DBT_TEST_TARGET_PREFIXES = _DBT_TEST_TARGET_PREFIXES
 
     # Characters that still change how an *explicit* `fqn:` selector is interpreted, so a component
@@ -139,7 +139,7 @@ class DbtFactory:
     # method explicitly bypasses that heuristic entirely. Verified: bare `probe.orders.sql` and
     # `probe.check/slash` select nothing, while `fqn:probe.orders.sql` and `fqn:probe.check/slash` each
     # resolve to exactly their node. `:` and literal braces are likewise literal under `fqn:`.
-    _SELECTOR_METACHARACTERS = frozenset(' ,*?[]')
+    _SELECTOR_METACHARACTERS = frozenset(" ,*?[]")
 
     @classmethod
     def _node_select(
@@ -217,31 +217,31 @@ class DbtFactory:
         # `test_type`, `resource_type`, `state`, `exposure`, `metric`, `result`, `source_status`,
         # `group`, `version`, `access`, `semantic_model`, `saved_query`, `unit_test`, `selector`.
         terms: list[str] = []
-        fqn = node_info.get('fqn') or []
+        fqn = node_info.get("fqn") or []
         # The `fqn:` prefix does *not* neutralise graph operators: `fqn:probe.orders+1` still selects
         # `orders` and its children, verified with `dbt ls` on dbt 1.12.0. The boundary check therefore
         # applies to the joined value; naming the method only bypasses the dispatch heuristic.
-        if fqn and cls._is_usable_selector('.'.join(fqn)) and all(cls._is_usable_component(part) for part in fqn):
+        if fqn and cls._is_usable_selector(".".join(fqn)) and all(cls._is_usable_component(part) for part in fqn):
             # `fqn:` names the method explicitly so `/` and `.sql` remain literal fqn text instead of
             # dispatching to path or file matching. `fqn:probe.orders.sql` and
             # `fqn:probe.check/slash` each resolve to exactly their node on dbt 1.12.0.
-            terms.append(f'fqn:{".".join(fqn)}')
-        elif cls._is_usable_component(name := node_info.get('name') or '') and cls._is_usable_selector(name):
+            terms.append(f"fqn:{'.'.join(fqn)}")
+        elif cls._is_usable_component(name := node_info.get("name") or "") and cls._is_usable_selector(name):
             # The fqn is unusable, so fall back to the bare resource name, which dbt matches against
             # the fqn's leaf. It is the only term that tells apart two nodes sharing a package, a
             # file and a test type — two `not_null` tests in one `schema.yml`, say. Not used *with* a
             # usable fqn, whose leaf already carries it.
-            terms.append(f'fqn:{name}')
+            terms.append(f"fqn:{name}")
         else:
             raise cls._unaddressable(node_info)
 
-        package = node_info.get('package_name') or ''
+        package = node_info.get("package_name") or ""
         if cls._is_usable_component(package):
-            terms.append(f'package:{package}')
+            terms.append(f"package:{package}")
 
-        file_name = cls._base_file_name(node_info.get('original_file_path') or '')
+        file_name = cls._base_file_name(node_info.get("original_file_path") or "")
         if cls._is_usable_component(file_name):
-            terms.append(f'file:{file_name}')
+            terms.append(f"file:{file_name}")
 
         # `resource_type:` separates nodes whose flattened fqns coincide across *types*, which the
         # other terms cannot: a unit test `unit_orders` on `orders` (fqn [probe, orders, unit_orders])
@@ -254,13 +254,13 @@ class DbtFactory:
         # expanded. Suppressing that expansion is the selection plan's job, not this term's: direct test
         # plans pin `--indirect-selection empty`, and parent-scoped cautious plans are accepted only when
         # `_eager_expansion_superset` proves the expanded result is the intended test alone.
-        resource_type = node_info.get('resource_type') or ''
+        resource_type = node_info.get("resource_type") or ""
         if cls._is_usable_component(resource_type):
-            terms.append(f'resource_type:{resource_type}')
+            terms.append(f"resource_type:{resource_type}")
 
-        test_name = (node_info.get('test_metadata') or {}).get('name') or ''
+        test_name = (node_info.get("test_metadata") or {}).get("name") or ""
         if cls._is_usable_component(test_name):
-            terms.append(f'test_name:{test_name}')
+            terms.append(f"test_name:{test_name}")
 
         select = cls._compose_selector_terms(terms, node_info)
         if peers is not None:
@@ -271,7 +271,7 @@ class DbtFactory:
     def _compose_selector_terms(cls, terms: list[str], node_info: dict) -> str:
         """Joins terms while preserving the required first term and omitting unsafe optional terms."""
         safe_terms = list(terms)
-        while match := DYNAMIC_VALUE_REFERENCE.search(select := ','.join(safe_terms)):
+        while match := DYNAMIC_VALUE_REFERENCE.search(select := ",".join(safe_terms)):
             offset = 0
             closing_term = 0
             for index, term in enumerate(safe_terms):
@@ -305,7 +305,7 @@ class DbtFactory:
         intended = cls._own_ids(test_info, peers)
         selected = set(cls._matching_ids(select, peers))
         if selected == intended:
-            return _SelectionPlan(select, 'empty')
+            return _SelectionPlan(select, "empty")
 
         surplus = selected - intended
         missing = intended - selected
@@ -321,14 +321,14 @@ class DbtFactory:
         parent_info = peers[parent_id]
         parent_select = cls._node_select(
             parent_info,
-            source_info=parent_info if parent_info.get('resource_type') == 'source' else None,
+            source_info=parent_info if parent_info.get("resource_type") == "source" else None,
             peers=peers,
         )
-        scoped_select = f'{parent_select},{select}'
+        scoped_select = f"{parent_select},{select}"
         cls._assert_no_dynamic_reference(scoped_select, test_info)
         if cls._eager_expansion_superset(scoped_select, peers) != intended:
             cls._assert_exact(select, test_info, peers)
-        return _SelectionPlan(scoped_select, 'cautious')
+        return _SelectionPlan(scoped_select, "cautious")
 
     @classmethod
     def _eager_expansion_superset(cls, select: str, peers: dict) -> set[str]:
@@ -345,7 +345,7 @@ class DbtFactory:
         and every exact-parent term matches its sole parent and therefore adds the test indirectly.
         """
         possible: set[str] | None = None
-        for term in select.split(','):
+        for term in select.split(","):
             direct = set(cls._matching_ids(term, peers))
             expanded = direct | cls._tests_attached_to_any(direct, peers)
             possible = expanded if possible is None else possible & expanded
@@ -359,7 +359,7 @@ class DbtFactory:
         return {
             full_name
             for full_name, info in peers.items()
-            if info.get('resource_type') in {'test', 'unit_test'} and cls._test_parent_ids(info) & parent_ids
+            if info.get("resource_type") in {"test", "unit_test"} and cls._test_parent_ids(info) & parent_ids
         }
 
     @classmethod
@@ -367,7 +367,7 @@ class DbtFactory:
         """Returns every model, seed, snapshot, or source dependency id, including absent resources."""
         return frozenset(
             dep
-            for dep in test_info.get('depends_on', {}).get('nodes', [])
+            for dep in test_info.get("depends_on", {}).get("nodes", [])
             if dep.startswith(cls._DBT_TEST_TARGET_PREFIXES)
         )
 
@@ -407,7 +407,7 @@ class DbtFactory:
         fallback for hand-written fixtures that omit the field — walking every peer here once per node was
         itself quadratic, and defeated the index added to avoid exactly that.
         """
-        own_id = node_info.get('unique_id')
+        own_id = node_info.get("unique_id")
         if own_id is not None and peers.get(own_id) is not None:
             return {own_id}
         return {full_name for full_name, info in peers.items() if info is node_info}
@@ -441,13 +441,13 @@ class DbtFactory:
         `source:pkg.raw.2+ord` resolves exactly — so the check goes on the assembled string rather
         than on each part.
         """
-        package = source_info.get('package_name') or ''
-        source_name = source_info.get('source_name') or ''
-        table = source_info.get('name') or ''
-        select = f'source:{package}.{source_name}.{table}'
+        package = source_info.get("package_name") or ""
+        source_name = source_info.get("source_name") or ""
+        table = source_info.get("name") or ""
+        select = f"source:{package}.{source_name}.{table}"
         cls._assert_no_dynamic_reference(select, source_info)
         parts = (package, source_name, table)
-        if not all(cls._is_usable_component(part) and '.' not in part for part in parts):
+        if not all(cls._is_usable_component(part) and "." not in part for part in parts):
             raise cls._unaddressable(source_info)
         if not cls._is_usable_selector(select):
             raise cls._unaddressable(source_info)
@@ -476,7 +476,7 @@ class DbtFactory:
         the command. The check applies after selector components are joined so references spanning
         components are also rejected.
         """
-        return not value.rstrip('0123456789').endswith('+') and DYNAMIC_VALUE_REFERENCE.search(value) is None
+        return not value.rstrip("0123456789").endswith("+") and DYNAMIC_VALUE_REFERENCE.search(value) is None
 
     @staticmethod
     def _flat_fqn(fqn: list[str]) -> list[str]:
@@ -502,19 +502,19 @@ class DbtFactory:
         would mean accepting a selector that matches two nodes, which is the whole bug class; the
         integration suite pins the mirror against `dbt ls`.
         """
-        fqn = node_info.get('fqn') or []
+        fqn = node_info.get("fqn") or []
         if not fqn:
             # A manifest missing `fqn` is not something dbt produces, but a hand-rolled or truncated one
             # can be, and the selector then falls back to the bare name. dbt would still match that name
             # against the fqn's leaf, so compare against the name rather than declining outright —
             # otherwise the exactness check reports a selector that reaches nothing.
-            return bool(node_info.get('name')) and node_info.get('name') == term
+            return bool(node_info.get("name")) and node_info.get("name") == term
         # dbt's `is_versioned` requires the resource type to be a model (`VERSIONED_NODE_TYPES`), not
         # merely that `version` is set — and a unit-test clone *does* carry `version`. Deriving it from
         # the field alone takes dbt's versioned branch for unit tests and so skips its plain
         # `fqn[-1] == term` match, making the mirror stricter than dbt and hiding a real collision on
         # such a node's bare-name selector.
-        is_versioned = node_info.get('resource_type') == 'model' and node_info.get('version') is not None
+        is_versioned = node_info.get("resource_type") == "model" and node_info.get("version") is not None
         return cls._is_selected_node(fqn, term, is_versioned) or cls._is_selected_node(fqn[1:], term, is_versioned)
 
     @classmethod
@@ -522,7 +522,7 @@ class DbtFactory:
         """Mirrors dbt's `is_selected_node` for the operator-free, wildcard-free terms we emit."""
         if not fqn:
             return False
-        selector_parts = term.split('.')
+        selector_parts = term.split(".")
         if cls._matches_fqn_leaf(fqn, term, selector_parts, is_versioned):
             return True
         flat_fqn = cls._flat_fqn(fqn)
@@ -546,40 +546,40 @@ class DbtFactory:
             return fqn[-1] == term
         if len(fqn) < 2:
             return False
-        return fqn[-2] == term or '_'.join(fqn[-2:]) == '_'.join(selector_parts[-2:])
+        return fqn[-2] == term or "_".join(fqn[-2:]) == "_".join(selector_parts[-2:])
 
     @classmethod
     def _term_matches(cls, term: str, node_info: dict) -> bool:
         """Whether one emitted selector term matches `node_info`."""
-        method, _, value = term.partition(':')
-        if not _ or method == 'fqn':
+        method, _, value = term.partition(":")
+        if not _ or method == "fqn":
             # A bare value is still accepted so a hand-written selector keeps working; everything the
             # factory emits now carries the explicit `fqn:` method.
-            return cls._fqn_term_matches(value if method == 'fqn' else term, node_info)
-        if method == 'source':
-            parts = value.split('.')
+            return cls._fqn_term_matches(value if method == "fqn" else term, node_info)
+        if method == "source":
+            parts = value.split(".")
             return (
                 len(parts) == 3
-                and node_info.get('resource_type') == 'source'
-                and (node_info.get('package_name') or '') == parts[0]
-                and (node_info.get('source_name') or '') == parts[1]
-                and (node_info.get('name') or '') == parts[2]
+                and node_info.get("resource_type") == "source"
+                and (node_info.get("package_name") or "") == parts[0]
+                and (node_info.get("source_name") or "") == parts[1]
+                and (node_info.get("name") or "") == parts[2]
             )
-        if method == 'package':
-            return (node_info.get('package_name') or '') == value
-        if method == 'file':
+        if method == "package":
+            return (node_info.get("package_name") or "") == value
+        if method == "file":
             # dbt's `FileSelectorMethod` matches the base name *or* its stem, so `file:a.yml` also
             # matches a node declared in `a.yml.yml`. Mirroring only the name would let that collision
             # past `_assert_exact` — confirmed with `dbt ls` on dbt 1.12.0, where the `a.yml` task's
             # selector resolves to the `a.yml.yml` test as well.
-            for base in _candidate_file_names(node_info.get('original_file_path') or ''):
-                if value in (base, base.rsplit('.', 1)[0] if '.' in base else base):
+            for base in _candidate_file_names(node_info.get("original_file_path") or ""):
+                if value in (base, base.rsplit(".", 1)[0] if "." in base else base):
                     return True
             return False
-        if method == 'resource_type':
-            return (node_info.get('resource_type') or '') == value
-        if method == 'test_name':
-            return ((node_info.get('test_metadata') or {}).get('name') or '') == value
+        if method == "resource_type":
+            return (node_info.get("resource_type") or "") == value
+        if method == "test_name":
+            return ((node_info.get("test_metadata") or {}).get("name") or "") == value
         return True  # pragma: no cover - no other method is emitted
 
     @staticmethod
@@ -602,7 +602,7 @@ class DbtFactory:
         scan to the nodes sharing this selector's `package:` and `file:`, which is a handful. A plain dict
         still works, for the unit tests and library callers that pass one.
         """
-        terms = select.split(',')
+        terms = select.split(",")
         scan = candidates.narrow(terms) if isinstance(candidates, _SelectorIndex) else candidates
         matched: list[str] = []
         for full_name, info in scan.items():
@@ -618,27 +618,27 @@ class DbtFactory:
         Distinct from `_unaddressable`: nothing about *this* resource's name is wrong, so the remedy is
         about the collision with its neighbours rather than about selector syntax.
         """
-        name = node_info.get('name')
-        path = node_info.get('original_file_path')
+        name = node_info.get("name")
+        path = node_info.get("original_file_path")
         return ValueError(
-            f'Cannot generate a task for {name!r} ({path}): the generated selector for it '
-            f'({select}) also runs {", ".join(sorted(also_matched))}. dbt has no unique-id selector, so '
-            f'the factory cannot prove a task addresses these separately. It does not search alternate '
-            f'spellings once a usable FQN exists, and refuses to risk running the others before their own '
-            f'dependencies have completed. Rename {name!r} so that its dotted '
-            f'name neither matches nor prefixes a '
+            f"Cannot generate a task for {name!r} ({path}): the generated selector for it "
+            f"({select}) also runs {', '.join(sorted(also_matched))}. dbt has no unique-id selector, so "
+            f"the factory cannot prove a task addresses these separately. It does not search alternate "
+            f"spellings once a usable FQN exists, and refuses to risk running the others before their own "
+            f"dependencies have completed. Rename {name!r} so that its dotted "
+            f"name neither matches nor prefixes a "
             f"sibling's, or move it to a file of its own."
         )
 
     @staticmethod
     def _dynamic_reference(node_info: dict, select: str) -> ValueError:
         """Builds the error for a selector Databricks would interpret as a dynamic value reference."""
-        name = node_info.get('name')
-        path = node_info.get('original_file_path')
+        name = node_info.get("name")
+        path = node_info.get("original_file_path")
         return ValueError(
-            f'Cannot generate a task for {name!r} ({path}): the final selector ({select}) contains a '
-            f'Databricks dynamic value reference. Rename the resource or file so its selector terms do '
-            f'not form a complete reference.'
+            f"Cannot generate a task for {name!r} ({path}): the final selector ({select}) contains a "
+            f"Databricks dynamic value reference. Rename the resource or file so its selector terms do "
+            f"not form a complete reference."
         )
 
     @staticmethod
@@ -650,13 +650,13 @@ class DbtFactory:
         is silent at run time: `dbt test` and `dbt run` exit 0 on a selector that matches nothing, so the
         task goes green having asserted or built nothing at all.
         """
-        name = node_info.get('name')
-        path = node_info.get('original_file_path')
+        name = node_info.get("name")
+        path = node_info.get("original_file_path")
         return ValueError(
-            f'Cannot generate a task for {name!r} ({path}): the selector dbt offers for it ({select}) '
-            f'does not reach {", ".join(missing)}. dbt exits 0 for a selector that matches nothing, so '
-            f'the task would report success having run nothing. This is a bug in selector construction '
-            f'rather than something to fix in the project — please report it.'
+            f"Cannot generate a task for {name!r} ({path}): the selector dbt offers for it ({select}) "
+            f"does not reach {', '.join(missing)}. dbt exits 0 for a selector that matches nothing, so "
+            f"the task would report success having run nothing. This is a bug in selector construction "
+            f"rather than something to fix in the project — please report it."
         )
 
     @staticmethod
@@ -667,13 +667,13 @@ class DbtFactory:
         This message is the whole of what a CLI user sees (`main` reports it without a traceback), so
         it leads with the resource and the remedy and keeps the reasoning to one closing line.
         """
-        name = node_info.get('name')
-        path = node_info.get('original_file_path')
+        name = node_info.get("name")
+        path = node_info.get("original_file_path")
         return ValueError(
-            f'Cannot generate a task for {name!r} ({path}): dbt cannot select it uniquely. '
-            f'Rename the resource or its file so that it does not end with a dbt graph operator (a '
-            f'trailing +N), contains none of a space, comma or one of *?[], and contains no complete '
-            f'Databricks dynamic value reference (`{{{{...}}}}`) — or, for a source, a dot. Without a '
+            f"Cannot generate a task for {name!r} ({path}): dbt cannot select it uniquely. "
+            f"Rename the resource or its file so that it does not end with a dbt graph operator (a "
+            f"trailing +N), contains none of a space, comma or one of *?[], and contains no complete "
+            f"Databricks dynamic value reference (`{{{{...}}}}`) — or, for a source, a dot. Without a "
             f"usable name or path, the only terms left match a group of "
             f"resources, so the task could run another task's resource."
         )
@@ -688,15 +688,15 @@ class DbtFactory:
         Returns:
             list[DbtTask]: `DbtTask` instances (not yet rendered to dicts).
         """
-        dbt_nodes = self._enabled_only(dbt_manifest.get('nodes', {}))
-        dbt_sources = self._enabled_only(dbt_manifest.get('sources', {}))
-        dbt_unit_tests = self._enabled_only(dbt_manifest.get('unit_tests', {}))
+        dbt_nodes = self._enabled_only(dbt_manifest.get("nodes", {}))
+        dbt_sources = self._enabled_only(dbt_manifest.get("sources", {}))
+        dbt_unit_tests = self._enabled_only(dbt_manifest.get("unit_tests", {}))
 
         # All directly selectable resources participate in selector exactness and test selection-plan
         # checks, including sources even though no emitted command builds a source directly.
         peers = _SelectorIndex({**dbt_nodes, **dbt_unit_tests, **dbt_sources})
 
-        bundle = 'test' in self.task_factories and self.bundle_tests
+        bundle = "test" in self.task_factories and self.bundle_tests
         bundled_tests: dict[str, list[tuple[str, dict]]] = {}
         standalone_tests: list[tuple[str, dict]] = []
         if bundle:
@@ -708,7 +708,7 @@ class DbtFactory:
         # here to receive a task key from `build_task_key_maps`.
         unit_test_ids = (
             self._emitted_unit_test_ids(dbt_unit_tests, dbt_nodes)
-            if not bundle and 'test' in self.task_factories
+            if not bundle and "test" in self.task_factories
             else []
         )
 
@@ -720,7 +720,7 @@ class DbtFactory:
         task_keys, bundled_test_keys = build_task_key_maps(task_ids, sorted(bundled_tests))
 
         gating = _Gating()
-        if not bundle and 'test' in self.task_factories:
+        if not bundle and "test" in self.task_factories:
             indexed_tests = self._index_tests_by_resource(dbt_nodes, dbt_sources, dbt_unit_tests, task_keys)
             gating = _Gating(
                 tests=indexed_tests,
@@ -749,7 +749,7 @@ class DbtFactory:
                 )
             )
             tasks.extend(self._build_standalone_test_tasks(standalone_tests, task_keys, peers))
-        elif 'test' in self.task_factories:
+        elif "test" in self.task_factories:
             tasks.extend(self._build_unit_test_tasks(dbt_unit_tests, task_keys, peers))
 
         return tasks
@@ -770,7 +770,7 @@ class DbtFactory:
         return {
             full_name: info
             for full_name, info in entries.items()
-            if (info.get('config') or {}).get('enabled') is not False
+            if (info.get("config") or {}).get("enabled") is not False
         }
 
     def _node_gets_own_task(self, full_name: str, node_info: dict, bundle: bool, standalone_test_ids: set[str]) -> bool:
@@ -780,10 +780,10 @@ class DbtFactory:
         into their resource's bundled test task. The single authority for this decision, so the
         task-key map and the task-building loops stay in agreement.
         """
-        resource_type = node_info['resource_type']
+        resource_type = node_info["resource_type"]
         if resource_type not in self.task_factories:
             return False
-        if bundle and resource_type == 'test' and full_name not in standalone_test_ids:
+        if bundle and resource_type == "test" and full_name not in standalone_test_ids:
             return False
         return True
 
@@ -817,7 +817,7 @@ class DbtFactory:
         dependents: dict[str, list[str]] = {full_name: [] for full_name in resources}
         for full_name, info in resources.items():
             direct_dependencies = {
-                dependency for dependency in info.get('depends_on', {}).get('nodes', []) if dependency in resources
+                dependency for dependency in info.get("depends_on", {}).get("nodes", []) if dependency in resources
             }
             dependencies[full_name] = direct_dependencies
             for dependency in direct_dependencies:
@@ -846,8 +846,8 @@ class DbtFactory:
             unresolved = {full_name for full_name, count in unresolved_counts.items() if count > 0}
             cycle = self._dependency_cycle(dependencies, unresolved)
             raise ValueError(
-                f'Cannot compute test gates because the manifest contains the dependency cycle '
-                f'{" -> ".join(cycle)}. Regenerate the manifest after removing the cycle.'
+                f"Cannot compute test gates because the manifest contains the dependency cycle "
+                f"{' -> '.join(cycle)}. Regenerate the manifest after removing the cycle."
             )
         return ancestors
 
@@ -885,7 +885,7 @@ class DbtFactory:
                 elif dependency_state == active:
                     return path[positions[dependency] :] + [dependency]
 
-        raise RuntimeError('A non-topological dependency graph did not contain a cycle.')
+        raise RuntimeError("A non-topological dependency graph did not contain a cycle.")
 
     def _index_tests_by_resource(
         self, dbt_nodes: dict, dbt_sources: dict, dbt_unit_tests: dict, task_keys: dict[str, str]
@@ -906,7 +906,7 @@ class DbtFactory:
         """
         index: dict[str, list[tuple[str, frozenset[str]]]] = {}
         for node_full_name, node_info in dbt_nodes.items():
-            if node_info['resource_type'] != 'test':
+            if node_info["resource_type"] != "test":
                 continue
             if node_full_name in task_keys:
                 self._index_test(index, task_keys[node_full_name], node_info, dbt_nodes, dbt_sources)
@@ -932,7 +932,7 @@ class DbtFactory:
     def _testable_refs(self, test_info: dict, dbt_nodes: dict, dbt_sources: dict) -> frozenset[str]:
         """Returns the models/seeds/snapshots/sources a test references, as present in the manifest."""
         refs: set[str] = set()
-        for dep in test_info.get('depends_on', {}).get('nodes', []):
+        for dep in test_info.get("depends_on", {}).get("nodes", []):
             if dep.startswith(self._DBT_TEST_TARGET_PREFIXES) and (dep in dbt_nodes or dep in dbt_sources):
                 refs.add(dep)
         return frozenset(refs)
@@ -950,13 +950,13 @@ class DbtFactory:
         test. Falls back to that reconstruction only when `depends_on` is absent, so manifests
         that predate it keep working.
         """
-        for dep in unit_test_info.get('depends_on', {}).get('nodes', []):
-            if dep.startswith('model.'):
+        for dep in unit_test_info.get("depends_on", {}).get("nodes", []):
+            if dep.startswith("model."):
                 return dep
-        model = unit_test_info.get('model')
-        package = unit_test_info.get('package_name')
+        model = unit_test_info.get("model")
+        package = unit_test_info.get("package_name")
         if model and package:
-            return f'model.{package}.{model}'
+            return f"model.{package}.{model}"
         return None
 
     @classmethod
@@ -1027,7 +1027,7 @@ class DbtFactory:
         bundled_tests: dict[str, list[tuple[str, dict]]] = {}
         standalone_tests: list[tuple[str, dict]] = []
         for node_full_name, node_info in dbt_nodes.items():
-            if node_info['resource_type'] != 'test':
+            if node_info["resource_type"] != "test":
                 continue
             testable_deps = self._testable_refs(node_info, dbt_nodes, dbt_sources)
             if len(testable_deps) == 1:
@@ -1058,18 +1058,18 @@ class DbtFactory:
         for node_full_name, node_info in dbt_nodes.items():
             if node_full_name not in task_keys:
                 continue
-            if bundle and node_info['resource_type'] == 'test':
+            if bundle and node_info["resource_type"] == "test":
                 # Standalone tests are keyed but built by `_build_standalone_test_tasks`, not here.
                 continue
 
-            resource_type = node_info['resource_type']
+            resource_type = node_info["resource_type"]
             task_key = task_keys[node_full_name]
             factory = self.task_factories[resource_type]
-            if resource_type == 'test':
+            if resource_type == "test":
                 plan = self._test_selection_plan(node_info, peers)
                 task = cast(TestTaskFactory, factory).create_task(
                     plan.select,
-                    node_info['name'],
+                    node_info["name"],
                     node_info,
                     task_key,
                     task_keys,
@@ -1078,7 +1078,7 @@ class DbtFactory:
             else:
                 task = factory.create_task(
                     self._node_select(node_info, peers=peers),
-                    node_info['name'],
+                    node_info["name"],
                     node_info,
                     task_key,
                     dependency_task_keys,
@@ -1111,10 +1111,10 @@ class DbtFactory:
         peers: dict,
     ) -> list[DbtTask]:
         """Emits one task per tested resource from unions of exact per-test selection plans."""
-        test_factory = cast(TestTaskFactory, self.task_factories['test'])
+        test_factory = cast(TestTaskFactory, self.task_factories["test"])
         tasks: list[DbtTask] = []
         for full_name, tests in sorted(bundled_tests.items()):
-            is_source = full_name.startswith('source.')
+            is_source = full_name.startswith("source.")
             info = dbt_sources[full_name] if is_source else dbt_nodes[full_name]
             # A source never gets a task of its own, so it has no gate. Any other parent must, or the
             # bundle would run its tests with nothing ordering them after the resource was built. Raise
@@ -1123,16 +1123,16 @@ class DbtFactory:
             # escape `main`'s handler as a traceback that names no resource.
             if not is_source and full_name not in task_keys:
                 raise ValueError(
-                    f'Cannot bundle the tests of {full_name!r}: no task was generated for it, so the '
-                    f'bundled test task would run unordered against it. Register a task factory for '
-                    f'{info.get("resource_type")!r} resources, or generate one task per test instead of '
-                    f'bundling.'
+                    f"Cannot bundle the tests of {full_name!r}: no task was generated for it, so the "
+                    f"bundled test task would run unordered against it. Register a task factory for "
+                    f"{info.get('resource_type')!r} resources, or generate one task per test instead of "
+                    f"bundling."
                 )
             tasks.append(
                 test_factory.create_bundled_task(
                     task_key=bundled_test_keys[full_name],
                     selects_by_indirect_selection=self._bundled_selects_by_mode(tests, peers),
-                    deps_command_name=info['name'],
+                    deps_command_name=info["name"],
                     depends_on=[] if is_source else [task_keys[full_name]],
                 )
             )
@@ -1148,7 +1148,7 @@ class DbtFactory:
             selects_by_mode.setdefault(plan.indirect_selection, []).append(plan.select)
             test_info_by_mode.setdefault(plan.indirect_selection, test_info)
         for mode, selects in selects_by_mode.items():
-            cls._assert_no_dynamic_reference(' '.join(sorted(selects)), test_info_by_mode[mode])
+            cls._assert_no_dynamic_reference(" ".join(sorted(selects)), test_info_by_mode[mode])
         return selects_by_mode
 
     def _build_standalone_test_tasks(
@@ -1162,7 +1162,7 @@ class DbtFactory:
         every referenced model, seed, or snapshot task, plus zero-dep singular tests that bundles
         cannot cover.
         """
-        test_factory = cast(TestTaskFactory, self.task_factories['test'])
+        test_factory = cast(TestTaskFactory, self.task_factories["test"])
         tasks: list[DbtTask] = []
         for test_full_name, test_info in sorted(standalone_tests, key=lambda item: item[0]):
             test_task_key = task_keys[test_full_name]
@@ -1170,7 +1170,7 @@ class DbtFactory:
             tasks.append(
                 test_factory.create_task(
                     plan.select,
-                    test_info['name'],
+                    test_info["name"],
                     test_info,
                     test_task_key,
                     task_keys,
@@ -1195,7 +1195,7 @@ class DbtFactory:
         Versioned unit-test clones receive independent parent-scoped selection plans, so each task waits
         only for and runs only against its exact model version.
         """
-        test_factory = cast(TestTaskFactory, self.task_factories['test'])
+        test_factory = cast(TestTaskFactory, self.task_factories["test"])
 
         tasks: list[DbtTask] = []
         for unit_test_full_name, unit_test_info in sorted(dbt_unit_tests.items()):
@@ -1205,7 +1205,7 @@ class DbtFactory:
             tasks.append(
                 test_factory.create_task(
                     plan.select,
-                    unit_test_info['name'],
+                    unit_test_info["name"],
                     unit_test_info,
                     task_keys[unit_test_full_name],
                     task_keys,
@@ -1246,21 +1246,21 @@ class _SelectorIndex(dict):
 
     def _index_test_parents(self, full_name: str, info: dict, peers: dict) -> None:
         """Indexes a test under each enabled testable parent."""
-        if info.get('resource_type') not in {'test', 'unit_test'}:
+        if info.get("resource_type") not in {"test", "unit_test"}:
             return
-        for parent in info.get('depends_on', {}).get('nodes', []):
+        for parent in info.get("depends_on", {}).get("nodes", []):
             if parent.startswith(_DBT_TEST_TARGET_PREFIXES) and parent in peers:
                 self._tests_by_parent.setdefault(parent, set()).add(full_name)
 
     def _add(self, full_name: str, info: dict) -> None:
         """Files one node under every key a selector term could reach it by."""
-        self._by_package.setdefault(info.get('package_name') or '', {})[full_name] = info
+        self._by_package.setdefault(info.get("package_name") or "", {})[full_name] = info
         # A path containing a backslash has both POSIX and Windows interpretations. Index every possible
         # base name and stem so narrowing cannot hide a collision under either runtime path flavour.
-        for base in _candidate_file_names(info.get('original_file_path') or ''):
-            for key in dict.fromkeys((base, base.rsplit('.', 1)[0] if '.' in base else base)):
+        for base in _candidate_file_names(info.get("original_file_path") or ""):
+            for key in dict.fromkeys((base, base.rsplit(".", 1)[0] if "." in base else base)):
                 self._by_file.setdefault(key, {})[full_name] = info
-        test_name = (info.get('test_metadata') or {}).get('name') or ''
+        test_name = (info.get("test_metadata") or {}).get("name") or ""
         if test_name:
             self._by_test_name.setdefault(test_name, {})[full_name] = info
         for term in self._fqn_terms(info):
@@ -1285,16 +1285,16 @@ class _SelectorIndex(dict):
         model), which can differ from a flattened prefix when it contains a dot. Version suffix matching
         is indexed separately because dbt ignores any earlier selector components in that shortcut.
         """
-        fqn = info.get('fqn') or []
+        fqn = info.get("fqn") or []
         if not fqn:
             # A truncated hand-written manifest can omit fqn; the matcher then falls back to the name.
-            name = info.get('name') or ''
+            name = info.get("name") or ""
             return {name} if name else set()
         terms: set[str] = set()
         for candidate in (fqn, fqn[1:]):
             flat = _flatten_fqn(candidate)
-            terms.update('.'.join(flat[:length]) for length in range(1, len(flat) + 1))
-        if info.get('resource_type') == 'model' and info.get('version') is not None and len(fqn) >= 2:
+            terms.update(".".join(flat[:length]) for length in range(1, len(flat) + 1))
+        if info.get("resource_type") == "model" and info.get("version") is not None and len(fqn) >= 2:
             terms.add(fqn[-2])
         else:
             terms.add(fqn[-1])
@@ -1303,10 +1303,10 @@ class _SelectorIndex(dict):
     @staticmethod
     def _version_suffix(info: dict) -> str:
         """The suffix used by dbt's versioned-model leaf shortcut, if this node has one."""
-        fqn = info.get('fqn') or []
-        if info.get('resource_type') == 'model' and info.get('version') is not None and len(fqn) >= 2:
-            return '_'.join(fqn[-2:])
-        return ''
+        fqn = info.get("fqn") or []
+        if info.get("resource_type") == "model" and info.get("version") is not None and len(fqn) >= 2:
+            return "_".join(fqn[-2:])
+        return ""
 
     def narrow(self, terms: list[str]) -> dict:
         """
@@ -1318,14 +1318,14 @@ class _SelectorIndex(dict):
         """
         smallest: dict | None = None
         for term in terms:
-            method, _, value = term.partition(':')
-            if not _ or method == 'fqn':
-                bucket = self._fqn_candidates(value if method == 'fqn' else term)
-            elif method == 'package':
+            method, _, value = term.partition(":")
+            if not _ or method == "fqn":
+                bucket = self._fqn_candidates(value if method == "fqn" else term)
+            elif method == "package":
                 bucket = self._by_package.get(value, {})
-            elif method == 'file':
+            elif method == "file":
                 bucket = self._by_file.get(value, {})
-            elif method == 'test_name':
+            elif method == "test_name":
                 bucket = self._by_test_name.get(value, {})
             else:
                 continue
@@ -1342,6 +1342,6 @@ class _SelectorIndex(dict):
         the selector's last two components, so its separate bucket is unioned here.
         """
         candidates = dict(self._by_fqn_term.get(term, {}))
-        suffix = '_'.join(term.split('.')[-2:])
+        suffix = "_".join(term.split(".")[-2:])
         candidates.update(self._by_version_suffix.get(suffix, {}))
         return candidates

--- a/src/databricks_dbt_factory/DbtTask.py
+++ b/src/databricks_dbt_factory/DbtTask.py
@@ -72,15 +72,15 @@ class DbtTaskOptions:
 
     def __post_init__(self):
         if not isinstance(self.task_type, TaskType):
-            object.__setattr__(self, 'task_type', TaskType(self.task_type))
+            object.__setattr__(self, "task_type", TaskType(self.task_type))
         if self.task_type is TaskType.NOTEBOOK:
             if not self.notebook_path:
                 raise ValueError("notebook_path is required when task_type=NOTEBOOK.")
             unsupported = []
             for name, value in (
-                ('warehouse_id', self.warehouse_id),
-                ('schema', self.schema),
-                ('catalog', self.catalog),
+                ("warehouse_id", self.warehouse_id),
+                ("schema", self.schema),
+                ("catalog", self.catalog),
             ):
                 if value:
                     unsupported.append(name)
@@ -108,66 +108,66 @@ class DbtTask:
 
     def _base_spec(self) -> dict[str, Any]:
         spec: dict[str, Any] = {
-            'task_key': self.task_key,
-            'depends_on': [{'task_key': dep} for dep in (self.depends_on or [])],
+            "task_key": self.task_key,
+            "depends_on": [{"task_key": dep} for dep in (self.depends_on or [])],
         }
         if self.options.job_cluster_key:
-            spec['job_cluster_key'] = self.options.job_cluster_key
+            spec["job_cluster_key"] = self.options.job_cluster_key
         else:
-            spec['environment_key'] = self.options.environment_key
+            spec["environment_key"] = self.options.environment_key
         return spec
 
     def _to_dbt_dict(self) -> dict[str, Any]:
         spec = self._base_spec()
-        dbt_task: dict[str, Any] = {'commands': self.commands}
+        dbt_task: dict[str, Any] = {"commands": self.commands}
 
         if self.options.source:
-            dbt_task['source'] = self.options.source
+            dbt_task["source"] = self.options.source
         if self.options.project_directory:
-            dbt_task['project_directory'] = self.options.project_directory
+            dbt_task["project_directory"] = self.options.project_directory
         if self.options.schema:
-            dbt_task['schema'] = self.options.schema
+            dbt_task["schema"] = self.options.schema
         if self.options.warehouse_id:
-            dbt_task['warehouse_id'] = self.options.warehouse_id
+            dbt_task["warehouse_id"] = self.options.warehouse_id
         if self.options.catalog:
-            dbt_task['catalog'] = self.options.catalog
+            dbt_task["catalog"] = self.options.catalog
         if self.options.profiles_directory:
-            dbt_task['profiles_directory'] = self.options.profiles_directory
+            dbt_task["profiles_directory"] = self.options.profiles_directory
 
-        spec['dbt_task'] = dbt_task
+        spec["dbt_task"] = dbt_task
         return spec
 
     def _to_notebook_dict(self) -> dict[str, Any]:
         serialized_commands = json.dumps(self.commands)
         if DYNAMIC_VALUE_REFERENCE.search(serialized_commands):
             raise ValueError(
-                f'Notebook task {self.task_key!r} serialized dbt_commands forms a Databricks dynamic value '
-                f'reference; rename the selected resources or change the dbt command options.'
+                f"Notebook task {self.task_key!r} serialized dbt_commands forms a Databricks dynamic value "
+                f"reference; rename the selected resources or change the dbt command options."
             )
         base_parameters: dict[str, str] = {
-            'dbt_commands': serialized_commands,
+            "dbt_commands": serialized_commands,
         }
         if self.options.project_directory:
-            base_parameters['project_directory'] = self.options.project_directory
+            base_parameters["project_directory"] = self.options.project_directory
         if self.options.profiles_directory:
-            base_parameters['profiles_directory'] = self.options.profiles_directory
+            base_parameters["profiles_directory"] = self.options.profiles_directory
 
-        serialized_size = len(json.dumps(base_parameters, ensure_ascii=False, separators=(',', ':')).encode('utf-8'))
+        serialized_size = len(json.dumps(base_parameters, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
         if serialized_size > _MAX_NOTEBOOK_BASE_PARAMETERS_BYTES:
             raise ValueError(
-                f'Notebook task {self.task_key!r} serializes base_parameters to {serialized_size:,} bytes; '
-                f'Databricks allows at most {_MAX_NOTEBOOK_BASE_PARAMETERS_BYTES:,} bytes. Shorten its dbt '
-                f'commands or path options, reduce the tests in this bundle, or generate native dbt tasks '
-                f'with --task-type dbt.'
+                f"Notebook task {self.task_key!r} serializes base_parameters to {serialized_size:,} bytes; "
+                f"Databricks allows at most {_MAX_NOTEBOOK_BASE_PARAMETERS_BYTES:,} bytes. Shorten its dbt "
+                f"commands or path options, reduce the tests in this bundle, or generate native dbt tasks "
+                f"with --task-type dbt."
             )
 
         notebook_task: dict[str, Any] = {
-            'notebook_path': self.options.notebook_path,
-            'base_parameters': base_parameters,
+            "notebook_path": self.options.notebook_path,
+            "base_parameters": base_parameters,
         }
         if self.options.source:
-            notebook_task['source'] = self.options.source
+            notebook_task["source"] = self.options.source
 
         spec = self._base_spec()
-        spec['notebook_task'] = notebook_task
+        spec["notebook_task"] = notebook_task
         return spec

--- a/src/databricks_dbt_factory/TaskFactory.py
+++ b/src/databricks_dbt_factory/TaskFactory.py
@@ -8,38 +8,38 @@ from databricks_dbt_factory.Utils import DYNAMIC_VALUE_REFERENCE
 
 _RESERVED_DBT_SELECTION_OPTIONS = frozenset(
     {
-        '--select',
-        '--models',
-        '--model',
-        '--exclude',
-        '--selector',
-        '--resource-type',
-        '--resource-types',
-        '--exclude-resource-type',
-        '--exclude-resource-types',
+        "--select",
+        "--models",
+        "--model",
+        "--exclude",
+        "--selector",
+        "--resource-type",
+        "--resource-types",
+        "--exclude-resource-type",
+        "--exclude-resource-types",
     }
 )
-_RESERVED_DBT_PARSE_CONTEXT_OPTIONS = frozenset({'--vars', '--profile', '--profiles-dir', '--project-dir'})
-_RESERVED_DBT_SHORT_SELECTION_OPTIONS = frozenset({'-s', '-m'})
-_RESERVED_DBT_SHORT_TARGET_OPTIONS = frozenset({'-t'})
-_DBT_SHORT_OPTIONS_WITH_ATTACHED_VALUES = frozenset({'-r', '-t'})
-_DBT_TARGET_OPTIONS_WITH_SEPARATE_VALUES = frozenset({'--target', '-t'})
-_DBT_TARGET_VALUE_ERROR = 'dbt target requires a nonempty value.'
+_RESERVED_DBT_PARSE_CONTEXT_OPTIONS = frozenset({"--vars", "--profile", "--profiles-dir", "--project-dir"})
+_RESERVED_DBT_SHORT_SELECTION_OPTIONS = frozenset({"-s", "-m"})
+_RESERVED_DBT_SHORT_TARGET_OPTIONS = frozenset({"-t"})
+_DBT_SHORT_OPTIONS_WITH_ATTACHED_VALUES = frozenset({"-r", "-t"})
+_DBT_TARGET_OPTIONS_WITH_SEPARATE_VALUES = frozenset({"--target", "-t"})
+_DBT_TARGET_VALUE_ERROR = "dbt target requires a nonempty value."
 _EXTRA_DBT_PARSE_CONTEXT_REMEDIES = {
-    '--target': '--target',
-    '-t': '--target',
-    '--profiles-dir': '--profiles-directory',
-    '--project-dir': '--project-directory',
+    "--target": "--target",
+    "-t": "--target",
+    "--profiles-dir": "--profiles-directory",
+    "--project-dir": "--project-directory",
 }
 
 
 def _reserved_short_option(token: str, reserved_options: frozenset[str]) -> str | None:
     """Returns a reserved option embedded in one dbt short-option token."""
-    if not token.startswith('-') or token.startswith('--'):
+    if not token.startswith("-") or token.startswith("--"):
         return None
 
     for character in token[1:]:
-        option = f'-{character}'
+        option = f"-{character}"
         if option in reserved_options:
             return option
         if option in _DBT_SHORT_OPTIONS_WITH_ATTACHED_VALUES:
@@ -49,7 +49,7 @@ def _reserved_short_option(token: str, reserved_options: frozenset[str]) -> str 
 
 def _reserved_parse_context_option(token: str) -> str | None:
     """Returns a parse-context option that is unsafe at every validation boundary."""
-    long_option = token.partition('=')[0]
+    long_option = token.partition("=")[0]
     if long_option in _RESERVED_DBT_PARSE_CONTEXT_OPTIONS:
         return long_option
     return None
@@ -57,17 +57,17 @@ def _reserved_parse_context_option(token: str) -> str | None:
 
 def _target_option(token: str) -> str | None:
     """Returns the target option represented by one token, including its short form."""
-    long_option = token.partition('=')[0]
-    if long_option == '--target':
+    long_option = token.partition("=")[0]
+    if long_option == "--target":
         return long_option
     return _reserved_short_option(token, _RESERVED_DBT_SHORT_TARGET_OPTIONS)
 
 
 def _reserved_selection_option(token: str) -> str | None:
     """Returns a selection option that conflicts with factory-owned selection."""
-    if token == '--':
+    if token == "--":
         return token
-    long_option = token.partition('=')[0]
+    long_option = token.partition("=")[0]
     if long_option in _RESERVED_DBT_SELECTION_OPTIONS:
         return long_option
     return _reserved_short_option(token, _RESERVED_DBT_SHORT_SELECTION_OPTIONS)
@@ -77,8 +77,8 @@ def _is_supported_leading_target(token: str) -> bool:
     """Returns whether a token is one of the controlled leading target forms."""
     return (
         token in _DBT_TARGET_OPTIONS_WITH_SEPARATE_VALUES
-        or token.startswith('--target=')
-        or (token.startswith('-t') and not token.startswith('--') and len(token) > 2)
+        or token.startswith("--target=")
+        or (token.startswith("-t") and not token.startswith("--") and len(token) > 2)
     )
 
 
@@ -86,14 +86,14 @@ def _raise_parse_context_error(option: str, reject_target: bool) -> None:
     """Raises the boundary-specific error for a runtime parse-context override."""
     if reject_target:
         dedicated_option = _EXTRA_DBT_PARSE_CONTEXT_REMEDIES.get(option)
-        remedy = f' Use the dedicated {dedicated_option} argument instead.' if dedicated_option else ''
+        remedy = f" Use the dedicated {dedicated_option} argument instead." if dedicated_option else ""
         raise ValueError(
-            f'--extra-dbt-command-options cannot include parse-context option {option!r}.{remedy} '
-            'The runtime parse context must match the supplied manifest.'
+            f"--extra-dbt-command-options cannot include parse-context option {option!r}.{remedy} "
+            "The runtime parse context must match the supplied manifest."
         )
     raise ValueError(
-        f'dbt command options cannot include parse-context option {option!r}; '
-        'the runtime parse context must match the supplied manifest.'
+        f"dbt command options cannot include parse-context option {option!r}; "
+        "the runtime parse context must match the supplied manifest."
     )
 
 
@@ -102,8 +102,8 @@ def _validate_dbt_option_token(token: str, token_index: int, reject_target: bool
     reserved_option = _reserved_selection_option(token)
     if reserved_option is not None:
         raise ValueError(
-            f'dbt command options cannot include selection option {reserved_option!r}; '
-            f'the factory owns selection so each task addresses only its intended resource.'
+            f"dbt command options cannot include selection option {reserved_option!r}; "
+            f"the factory owns selection so each task addresses only its intended resource."
         )
 
     target_option = _target_option(token)
@@ -112,10 +112,10 @@ def _validate_dbt_option_token(token: str, token_index: int, reject_target: bool
             _raise_parse_context_error(target_option, reject_target=True)
         if token_index != 0 or not _is_supported_leading_target(token):
             raise ValueError(
-                'dbt command options can include at most one target, only as the leading '
-                f'factory-controlled option; found {target_option!r} elsewhere.'
+                "dbt command options can include at most one target, only as the leading "
+                f"factory-controlled option; found {target_option!r} elsewhere."
             )
-        if token == '--target=':
+        if token == "--target=":
             raise ValueError(_DBT_TARGET_VALUE_ERROR)
         return token in _DBT_TARGET_OPTIONS_WITH_SEPARATE_VALUES
 
@@ -129,13 +129,13 @@ def _validate_dbt_options(dbt_options: str, reject_target: bool) -> None:
     """Rejects options that can invalidate the factory's manifest-derived task guarantees."""
     if DYNAMIC_VALUE_REFERENCE.search(dbt_options):
         raise ValueError(
-            'dbt command options cannot contain a Databricks dynamic value reference; '
-            'its runtime value could change the resource selection owned by the factory.'
+            "dbt command options cannot contain a Databricks dynamic value reference; "
+            "its runtime value could change the resource selection owned by the factory."
         )
     try:
         tokens = shlex.split(dbt_options)
     except ValueError as error:
-        raise ValueError(f'Cannot parse dbt command options: {error}.') from error
+        raise ValueError(f"Cannot parse dbt command options: {error}.") from error
 
     option_value_expected = False
     for token_index, token in enumerate(tokens):
@@ -366,7 +366,7 @@ class TestTaskFactory(TaskFactory):
         dbt_node_info: dict,
         task_key: str,
         task_keys: dict[str, str],
-        indirect_selection: str = 'empty',
+        indirect_selection: str = "empty",
     ) -> DbtTask:
         """
         Creates a test task for a single dbt test node.
@@ -418,10 +418,10 @@ class TestTaskFactory(TaskFactory):
         """
         dbt_deps = self.get_dbt_deps_command(deps_command_name)
         commands = [dbt_deps] if dbt_deps else []
-        unsupported_modes = set(selects_by_indirect_selection) - {'empty', 'cautious'}
+        unsupported_modes = set(selects_by_indirect_selection) - {"empty", "cautious"}
         if unsupported_modes:
-            raise ValueError(f'Unsupported dbt indirect-selection modes: {", ".join(sorted(unsupported_modes))}.')
-        for indirect_selection in ('empty', 'cautious'):
+            raise ValueError(f"Unsupported dbt indirect-selection modes: {', '.join(sorted(unsupported_modes))}.")
+        for indirect_selection in ("empty", "cautious"):
             if indirect_selection not in selects_by_indirect_selection:
                 continue
             selects = sorted(selects_by_indirect_selection[indirect_selection])

--- a/src/databricks_dbt_factory/Utils.py
+++ b/src/databricks_dbt_factory/Utils.py
@@ -4,13 +4,13 @@ import re
 from collections.abc import Iterable
 
 # Databricks substitutes complete dynamic value references in task string fields before execution.
-DYNAMIC_VALUE_REFERENCE = re.compile(r'\{\{[^{}]+\}\}')
+DYNAMIC_VALUE_REFERENCE = re.compile(r"\{\{[^{}]+\}\}")
 
 # Databricks caps task keys at 100 characters (letters, numbers, underscores, hyphens).
 MAX_TASK_KEY_LENGTH = 100
 
 # dbt resource types whose task key is `<resource_name>_<type>` (the type doubles as the suffix).
-_SUFFIXED_TYPES = frozenset({'model', 'seed', 'snapshot'})
+_SUFFIXED_TYPES = frozenset({"model", "seed", "snapshot"})
 
 
 def _resource_name(unique_id: str) -> str:
@@ -18,7 +18,7 @@ def _resource_name(unique_id: str) -> str:
     The dbt resource name — everything after `<type>.<package>.` — with dots turned into
     underscores. Keeps a versioned model's version, e.g. `model.shop.dim.v2` -> `dim_v2`.
     """
-    return '_'.join(unique_id.split('.')[2:])
+    return "_".join(unique_id.split(".")[2:])
 
 
 def _source_key(parts: list[str], with_package: bool) -> str:
@@ -26,18 +26,18 @@ def _source_key(parts: list[str], with_package: bool) -> str:
     Test-task key for a source (`source.<package>.<source_name>.<table>`): `<source_name>_<table>_test`,
     package-prefixed (`<package>_<source_name>_<table>_test`) when disambiguating a collision.
     """
-    prefix = f'{parts[1]}_' if with_package else ''
-    return f'{prefix}{parts[2]}_{parts[3]}_test'
+    prefix = f"{parts[1]}_" if with_package else ""
+    return f"{prefix}{parts[2]}_{parts[3]}_test"
 
 
 def _sanitized_id(unique_id: str) -> str:
     """Fallback key for an unhandled resource type: the sanitized `unique_id` (dots -> underscores)."""
-    return unique_id.replace('.', '_')
+    return unique_id.replace(".", "_")
 
 
 # Minimum dot-separated segment count required to build a key for each resource type. dbt ids are
 # `<type>.<package>.<name>[...]`; sources are `source.<package>.<source_name>.<table>`.
-_MIN_SEGMENTS = {'model': 3, 'seed': 3, 'snapshot': 3, 'test': 3, 'source': 4}
+_MIN_SEGMENTS = {"model": 3, "seed": 3, "snapshot": 3, "test": 3, "source": 4}
 
 
 def _split_unique_id(unique_id: str) -> list[str]:
@@ -46,10 +46,10 @@ def _split_unique_id(unique_id: str) -> list[str]:
     for its resource type. Raises `ValueError` with a clear message on a malformed id (e.g. a
     name-less `model.pkg`, or a source missing its table).
     """
-    parts = unique_id.split('.')
+    parts = unique_id.split(".")
     minimum = _MIN_SEGMENTS.get(parts[0])
     if minimum is not None and len(parts) < minimum:
-        raise ValueError(f'Malformed dbt node id {unique_id!r}: expected at least {minimum} dot-separated segments.')
+        raise ValueError(f"Malformed dbt node id {unique_id!r}: expected at least {minimum} dot-separated segments.")
     return parts
 
 
@@ -76,15 +76,15 @@ def generate_task_key(unique_id: str) -> str:
     resource_type = parts[0]
 
     if resource_type in _SUFFIXED_TYPES:
-        return f'{_resource_name(unique_id)}_{resource_type}'
+        return f"{_resource_name(unique_id)}_{resource_type}"
 
-    if resource_type == 'source':
+    if resource_type == "source":
         # A source only ever surfaces as a test task: source.<package>.<source_name>.<table>.
         return _source_key(parts, with_package=False)
 
-    if resource_type == 'test':
+    if resource_type == "test":
         # test.<package>.<test_name>[.<hash>] -> <test_name>_test (drop dbt's uniqueness hash).
-        test_hash = parts[3] if len(parts) > 3 else ''
+        test_hash = parts[3] if len(parts) > 3 else ""
         return _bounded_test_key(parts[2], test_hash)
 
     # Unknown type: fall back to the sanitized id (still unique).
@@ -97,9 +97,9 @@ def bundled_test_key(unique_id: str) -> str:
     `model.shop.orders` -> `orders_test`; `source.shop.raw.customers` -> `raw_customers_test`.
     """
     parts = _split_unique_id(unique_id)
-    if parts[0] == 'source':
+    if parts[0] == "source":
         return _source_key(parts, with_package=False)
-    return f'{_resource_name(unique_id)}_test'
+    return f"{_resource_name(unique_id)}_test"
 
 
 def build_task_key_maps(
@@ -165,7 +165,7 @@ def _reserve(candidate: str, taken: set[str]) -> str:
         return key
     counter = 2
     while True:
-        key = _bounded(f'{candidate}_{counter}')
+        key = _bounded(f"{candidate}_{counter}")
         if key not in taken:
             taken.add(key)
             return key
@@ -179,8 +179,8 @@ def _bounded(key: str) -> str:
     """
     if len(key) <= MAX_TASK_KEY_LENGTH:
         return key
-    digest = hashlib.sha256(key.encode('utf-8')).hexdigest()[:8]
-    return f'{key[: MAX_TASK_KEY_LENGTH - len(digest) - 1]}_{digest}'
+    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:8]
+    return f"{key[: MAX_TASK_KEY_LENGTH - len(digest) - 1]}_{digest}"
 
 
 def _disambiguated_task_key(unique_id: str) -> str:
@@ -190,30 +190,30 @@ def _disambiguated_task_key(unique_id: str) -> str:
     e.g. `test.shop.dup_check.9a1` -> `dup_check_9a1_test`, `model.pkg.orders` ->
     `pkg_orders_model`.
     """
-    parts = unique_id.split('.')
+    parts = unique_id.split(".")
     resource_type = parts[0]
     if resource_type in _SUFFIXED_TYPES:
-        return f'{parts[1]}_{_resource_name(unique_id)}_{resource_type}'
-    if resource_type == 'source':
+        return f"{parts[1]}_{_resource_name(unique_id)}_{resource_type}"
+    if resource_type == "source":
         return _source_key(parts, with_package=True)
-    if resource_type == 'test':
+    if resource_type == "test":
         if len(parts) > 3:
             return _hashed_test_key(parts[2], parts[3])
-        return f'{parts[1]}_{parts[2]}_test'
+        return f"{parts[1]}_{parts[2]}_test"
     return _sanitized_id(unique_id)
 
 
 def _disambiguated_bundled_test_key(unique_id: str) -> str:
     """Package-prefixed variant of `bundled_test_key`, for contested bundled test keys."""
-    parts = unique_id.split('.')
-    if parts[0] == 'source':
+    parts = unique_id.split(".")
+    if parts[0] == "source":
         return _source_key(parts, with_package=True)
-    return f'{parts[1]}_{_resource_name(unique_id)}_test'
+    return f"{parts[1]}_{_resource_name(unique_id)}_test"
 
 
 def _bounded_test_key(test_name: str, test_hash: str) -> str:
     """`<test_name>_test`, truncated and hash-disambiguated if it exceeds the key length limit."""
-    key = f'{test_name}_test'
+    key = f"{test_name}_test"
     if len(key) <= MAX_TASK_KEY_LENGTH:
         return key
     return _hashed_test_key(test_name, test_hash)
@@ -221,7 +221,7 @@ def _bounded_test_key(test_name: str, test_hash: str) -> str:
 
 def _hashed_test_key(test_name: str, test_hash: str) -> str:
     """`<test_name>_<hash>_test`, truncating the name so the hash survives the length limit."""
-    tail = (f'_{test_hash}' if test_hash else '') + '_test'
+    tail = (f"_{test_hash}" if test_hash else "") + "_test"
     if len(test_name) + len(tail) <= MAX_TASK_KEY_LENGTH:
         return test_name + tail
     return test_name[: MAX_TASK_KEY_LENGTH - len(tail)] + tail
@@ -244,12 +244,12 @@ def read_dbt_manifest(path: str) -> dict:
             `manifest.get(...)`, which `main` does not catch — a traceback instead of a clean `error:`.
     """
     try:
-        with open(path, 'r', encoding='utf-8') as file:
+        with open(path, "r", encoding="utf-8") as file:
             manifest = json.load(file)
     except FileNotFoundError as e:
-        raise FileNotFoundError(f'Manifest file not found: {path}. Details: {e}') from e
+        raise FileNotFoundError(f"Manifest file not found: {path}. Details: {e}") from e
     except json.JSONDecodeError as e:
-        raise ValueError(f'Error parsing JSON from manifest file: {path}. Details: {e}') from e
+        raise ValueError(f"Error parsing JSON from manifest file: {path}. Details: {e}") from e
     if not isinstance(manifest, dict):
-        raise ValueError(f'Manifest file {path} must contain a JSON object, got {type(manifest).__name__}.')
+        raise ValueError(f"Manifest file {path} must contain a JSON object, got {type(manifest).__name__}.")
     return manifest

--- a/src/databricks_dbt_factory/file_io.py
+++ b/src/databricks_dbt_factory/file_io.py
@@ -33,10 +33,10 @@ def _prepared_temporary_path(target: Path, content: bytes, mode: int) -> Iterato
     published = False
     try:
         with tempfile.NamedTemporaryFile(
-            mode='wb',
+            mode="wb",
             dir=target.parent,
-            prefix='.dbf-',
-            suffix='.tmp',
+            prefix=".dbf-",
+            suffix=".tmp",
             delete=False,
         ) as temporary_file:
             temporary_path = Path(temporary_file.name)

--- a/src/databricks_dbt_factory/job_spec.py
+++ b/src/databricks_dbt_factory/job_spec.py
@@ -61,7 +61,7 @@ def render_job_spec(
             that an unexpected manifest shape raises from the factory — those are bugs, and swallowing
             them turns a diagnosable traceback into `error: 'resource_type'`.
     """
-    with open(input_job_spec_path, 'r', encoding="utf-8") as file:
+    with open(input_job_spec_path, "r", encoding="utf-8") as file:
         try:
             job_definition = yaml.safe_load(file)
         except yaml.YAMLError as error:
@@ -72,8 +72,8 @@ def render_job_spec(
     # and assigns into the job, so a non-mapping anywhere raises `AttributeError`/`TypeError`, which escapes
     # `main`'s `except (ValueError, FileNotFoundError)` and prints a traceback for a malformed *input file*
     # — the outcome this guard exists to prevent.
-    resources = job_definition.get('resources') if isinstance(job_definition, dict) else None
-    jobs = resources.get('jobs') if isinstance(resources, dict) else None
+    resources = job_definition.get("resources") if isinstance(job_definition, dict) else None
+    jobs = resources.get("jobs") if isinstance(resources, dict) else None
     if not isinstance(jobs, dict) or not jobs:
         raise ValueError(f"No jobs found in {input_job_spec_path}.")
 
@@ -93,8 +93,8 @@ def render_job_spec(
 
     first_job = jobs[first_job_key]
     if new_job_name:
-        first_job['name'] = new_job_name
-    first_job['tasks'] = new_tasks  # Replace tasks field
+        first_job["name"] = new_job_name
+    first_job["tasks"] = new_tasks  # Replace tasks field
 
     return yaml.dump(job_definition, sort_keys=False, width=1000)
 
@@ -103,7 +103,7 @@ def resolve_job_spec_destination(target_job_spec_path: str | Path) -> Path:
     """Validates a requested job spec target and returns its canonical destination."""
     requested_destination = Path(target_job_spec_path)
     if requested_destination.is_symlink() or (requested_destination.exists() and not requested_destination.is_file()):
-        raise ValueError(f'Job spec target {requested_destination} must be a regular non-symlink file.')
+        raise ValueError(f"Job spec target {requested_destination} must be a regular non-symlink file.")
     return requested_destination.resolve()
 
 
@@ -111,7 +111,7 @@ def prepare_job_spec(rendered: str, input_job_spec_path: str, destination: Path)
     """Encodes a rendered spec and resolves the mode its atomic replacement must use."""
     mode_source = destination if destination.exists() else Path(input_job_spec_path)
     mode = stat.S_IMODE(mode_source.stat().st_mode)
-    return JobSpecArtifact(rendered.encode('utf-8'), destination, mode)
+    return JobSpecArtifact(rendered.encode("utf-8"), destination, mode)
 
 
 def write_job_spec(artifact: JobSpecArtifact) -> None:

--- a/src/databricks_dbt_factory/main.py
+++ b/src/databricks_dbt_factory/main.py
@@ -84,9 +84,9 @@ def _validate_runner_notebook(artifact: _RunnerArtifact) -> None:
     """Rejects any existing runner target that cannot be safely reused as immutable content."""
     destination = artifact.destination
     if destination.is_symlink() or (destination.exists() and not destination.is_file()):
-        raise ValueError(f'Runner target {destination} must be a regular non-symlink file.')
+        raise ValueError(f"Runner target {destination} must be a regular non-symlink file.")
     if destination.exists() and destination.read_bytes() != artifact.content:
-        raise ValueError(f'Runner target {destination} does not match its SHA-256 filename.')
+        raise ValueError(f"Runner target {destination} does not match its SHA-256 filename.")
 
 
 def _prepare_output_plan(args: argparse.Namespace) -> _OutputPlan:
@@ -149,12 +149,12 @@ def _create_dbt_factory(args: argparse.Namespace, output_plan: _OutputPlan, dbt_
         job_cluster_key=args.job_cluster_key,
     )
     task_factories = {
-        'model': ModelTaskFactory(resolver, task_options, dbt_options),
-        'snapshot': SnapshotTaskFactory(resolver, task_options, dbt_options),
-        'seed': SeedTaskFactory(resolver, task_options, dbt_options),
+        "model": ModelTaskFactory(resolver, task_options, dbt_options),
+        "snapshot": SnapshotTaskFactory(resolver, task_options, dbt_options),
+        "seed": SeedTaskFactory(resolver, task_options, dbt_options),
     }
     if args.run_tests:
-        task_factories['test'] = TestTaskFactory(resolver, task_options, dbt_options)
+        task_factories["test"] = TestTaskFactory(resolver, task_options, dbt_options)
     return DbtFactory(task_factories, bundle_tests=args.bundle_tests)
 
 
@@ -165,7 +165,7 @@ def _validate_artifact_destinations(
     if runner_artifact is None:
         return
     if runner_artifact.destination.resolve() == job_spec_artifact.destination.resolve():
-        raise ValueError(f'runner and job spec destinations must be different: {runner_artifact.destination}')
+        raise ValueError(f"runner and job spec destinations must be different: {runner_artifact.destination}")
     _validate_runner_notebook(runner_artifact)
 
 
@@ -198,7 +198,7 @@ def _publish_artifacts(runner_artifact: _RunnerArtifact | None, job_spec_artifac
         if job_spec_artifact.destination.exists() and runner_artifact.destination.samefile(
             job_spec_artifact.destination
         ):
-            raise ValueError(f'runner and job spec destinations must be different: {runner_artifact.destination}')
+            raise ValueError(f"runner and job spec destinations must be different: {runner_artifact.destination}")
     write_job_spec(job_spec_artifact)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,10 +56,10 @@ def create_dbt_factory(
         notebook_path=notebook_path,
     )
     task_factories = {
-        'model': ModelTaskFactory(resolver, task_options, dbt_options),
-        'snapshot': SnapshotTaskFactory(resolver, task_options, dbt_options),
-        'seed': SeedTaskFactory(resolver, task_options, dbt_options),
-        'test': TestTaskFactory(resolver, task_options, dbt_options),
+        "model": ModelTaskFactory(resolver, task_options, dbt_options),
+        "snapshot": SnapshotTaskFactory(resolver, task_options, dbt_options),
+        "seed": SeedTaskFactory(resolver, task_options, dbt_options),
+        "test": TestTaskFactory(resolver, task_options, dbt_options),
     }
 
     return DbtFactory(task_factories, bundle_tests=bundle_tests)

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -58,9 +58,9 @@ def _run_cli(*args: str) -> subprocess.CompletedProcess:
         text=True,
         check=False,
     )
-    assert (
-        result.returncode == 0
-    ), f"CLI failed (exit {result.returncode})\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert result.returncode == 0, (
+        f"CLI failed (exit {result.returncode})\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
     return result
 
 

--- a/tests/integration/test_distribution.py
+++ b/tests/integration/test_distribution.py
@@ -95,9 +95,9 @@ def _assert_wheel_executes_in_isolation(wheel: Path, tmp_path: Path) -> None:
         text=True,
         check=False,
     )
-    assert (
-        result.returncode == 0
-    ), f"isolated wheel execution failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert result.returncode == 0, (
+        f"isolated wheel execution failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
     assert "--dbt-manifest-path" in result.stdout
 
 

--- a/tests/integration/test_selector_against_dbt.py
+++ b/tests/integration/test_selector_against_dbt.py
@@ -51,7 +51,7 @@ probe:
       schema: default
 """
 
-MODEL_SQL = 'select 1 as id\n'
+MODEL_SQL = "select 1 as id\n"
 
 
 def _write_project(
@@ -59,7 +59,7 @@ def _write_project(
     model_paths: dict[str, str],
     schema_yml: str | None = None,
     package_model_paths: dict[str, str] | None = None,
-    model_search_path: str = 'models',
+    model_search_path: str = "models",
 ) -> None:
     """
     Writes a minimal dbt project.
@@ -71,32 +71,32 @@ def _write_project(
     """
     project = (
         'name: probe\nprofile: probe\nversion: "1.0"\nconfig-version: 2\n'
-        f'model-paths: [{json.dumps(model_search_path)}]\n'
+        f"model-paths: [{json.dumps(model_search_path)}]\n"
     )
     if package_model_paths:
         # A distinct schema keeps the two packages' relations from colliding, which dbt rejects.
-        project += 'models:\n  other:\n    +schema: otherschema\n'
-        (root / 'packages.yml').write_text('packages:\n  - local: libs/other\n', encoding='utf-8')
-        package_root = root / 'libs' / 'other'
+        project += "models:\n  other:\n    +schema: otherschema\n"
+        (root / "packages.yml").write_text("packages:\n  - local: libs/other\n", encoding="utf-8")
+        package_root = root / "libs" / "other"
         package_root.mkdir(parents=True, exist_ok=True)
-        (package_root / 'dbt_project.yml').write_text(
-            'name: other\nversion: "1.0"\nconfig-version: 2\nmodel-paths: ["models"]\n', encoding='utf-8'
+        (package_root / "dbt_project.yml").write_text(
+            'name: other\nversion: "1.0"\nconfig-version: 2\nmodel-paths: ["models"]\n', encoding="utf-8"
         )
         for relative_path, sql in package_model_paths.items():
-            target = package_root / 'models' / relative_path
+            target = package_root / "models" / relative_path
             target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(sql, encoding='utf-8')
-    (root / 'dbt_project.yml').write_text(project, encoding='utf-8')
-    (root / 'profiles.yml').write_text(PROFILES, encoding='utf-8')
+            target.write_text(sql, encoding="utf-8")
+    (root / "dbt_project.yml").write_text(project, encoding="utf-8")
+    (root / "profiles.yml").write_text(PROFILES, encoding="utf-8")
     for relative_path, sql in model_paths.items():
         target = root / model_search_path / relative_path
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(sql, encoding='utf-8')
+        target.write_text(sql, encoding="utf-8")
     if schema_yml is not None:
-        (root / model_search_path / 'schema.yml').write_text(schema_yml, encoding='utf-8')
+        (root / model_search_path / "schema.yml").write_text(schema_yml, encoding="utf-8")
     if package_model_paths:
-        result = _dbt(root, 'deps', '--quiet')
-        assert result.success, f'dbt deps failed for the generated project: {result.exception}'
+        result = _dbt(root, "deps", "--quiet")
+        assert result.success, f"dbt deps failed for the generated project: {result.exception}"
 
 
 def _dbt(root: Path, *args: str) -> dbtRunnerResult:
@@ -107,14 +107,14 @@ def _dbt(root: Path, *args: str) -> dbtRunnerResult:
     directory: `os.chdir` in a test leaks into everything else in the process, and under
     `pytest-cov` it makes coverage write its data file to the wrong place.
     """
-    return dbtRunner().invoke([*args, '--project-dir', str(root), '--profiles-dir', str(root)])
+    return dbtRunner().invoke([*args, "--project-dir", str(root), "--profiles-dir", str(root)])
 
 
 def _parse(root: Path) -> dict:
     """Parses the project with dbt and returns its real manifest, failing loudly if dbt cannot."""
-    result = _dbt(root, 'parse', '--quiet')
-    assert result.success, f'dbt could not parse the generated project: {result.exception}'
-    return json.loads((root / 'target' / 'manifest.json').read_text(encoding='utf-8'))
+    result = _dbt(root, "parse", "--quiet")
+    assert result.success, f"dbt could not parse the generated project: {result.exception}"
+    return json.loads((root / "target" / "manifest.json").read_text(encoding="utf-8"))
 
 
 def _select_args(select: str | tuple[str, ...]) -> list[str]:
@@ -125,7 +125,7 @@ def _select_args(select: str | tuple[str, ...]) -> list[str]:
     the first one silently checks a fraction of what the task runs.
     """
     selectors = (select,) if isinstance(select, str) else select
-    return [argument for selector in selectors for argument in ('--select', selector)]
+    return [argument for selector in selectors for argument in ("--select", selector)]
 
 
 @functools.lru_cache(maxsize=None)
@@ -142,18 +142,18 @@ def _selected_ids(
     Memoised: a `dbt ls` invocation costs a few hundred milliseconds, and the same selector recurs
     across per-test and bundled mode, so caching keeps the suite inside the project's test timeout.
     """
-    args = ['ls', '--quiet', *_select_args(select)]
+    args = ["ls", "--quiet", *_select_args(select)]
     if resource_type:
-        args += ['--resource-type', resource_type]
+        args += ["--resource-type", resource_type]
     if indirect:
-        args += ['--indirect-selection', 'cautious']
+        args += ["--indirect-selection", "cautious"]
     elif indirect_selection:
-        args += ['--indirect-selection', indirect_selection]
+        args += ["--indirect-selection", indirect_selection]
     result = _dbt(root, *args)
-    assert result.success, f'dbt ls failed for {select!r}: {result.exception}'
+    assert result.success, f"dbt ls failed for {select!r}: {result.exception}"
     # `dbt ls` returns a list of unique-id strings; the runner's result type is a union across every
     # dbt command, so narrow it here rather than trusting the annotation.
-    assert isinstance(result.result, list), f'expected dbt ls to return a list, got {type(result.result)}'
+    assert isinstance(result.result, list), f"expected dbt ls to return a list, got {type(result.result)}"
     return tuple(sorted(str(unique_id) for unique_id in result.result))
 
 
@@ -167,15 +167,15 @@ def _selected_unique_ids(
     `dbt ls` prints selector names by default (`probe.orders`), which do not match manifest keys — so a
     comparison against manifest ids has to ask for `--output json --output-keys unique_id` instead.
     """
-    args = ['ls', '--quiet', *_select_args(select), '--output', 'json', '--output-keys', 'unique_id']
+    args = ["ls", "--quiet", *_select_args(select), "--output", "json", "--output-keys", "unique_id"]
     if resource_type:
-        args += ['--resource-type', resource_type]
+        args += ["--resource-type", resource_type]
     if indirect_selection:
-        args += ['--indirect-selection', indirect_selection]
+        args += ["--indirect-selection", indirect_selection]
     result = _dbt(root, *args)
-    assert result.success, f'dbt ls failed for {select!r}: {result.exception}'
-    assert isinstance(result.result, list), f'expected dbt ls to return a list, got {type(result.result)}'
-    return tuple(sorted(json.loads(entry)['unique_id'] for entry in result.result))
+    assert result.success, f"dbt ls failed for {select!r}: {result.exception}"
+    assert isinstance(result.result, list), f"expected dbt ls to return a list, got {type(result.result)}"
+    return tuple(sorted(json.loads(entry)["unique_id"] for entry in result.result))
 
 
 def _command_selectors(command: Sequence[str]) -> tuple[str, ...]:
@@ -185,7 +185,7 @@ def _command_selectors(command: Sequence[str]) -> tuple[str, ...]:
     A bundled task emits one `--select` per member, so reading only the first would replay a fraction
     of what the task runs and let a missing member pass unnoticed.
     """
-    return tuple(command[index + 1] for index, value in enumerate(command[:-1]) if value == '--select')
+    return tuple(command[index + 1] for index, value in enumerate(command[:-1]) if value == "--select")
 
 
 def _has_source_selector(selector_groups: Iterable[tuple[str, ...]]) -> bool:
@@ -195,7 +195,7 @@ def _has_source_selector(selector_groups: Iterable[tuple[str, ...]]) -> bool:
     Checks every term of every bundled union, not just the first: a `source:` term reached only in the
     middle of a bundle is exactly the case these tests exist to catch.
     """
-    return any(selector.startswith('source:') for selectors in selector_groups for selector in selectors)
+    return any(selector.startswith("source:") for selectors in selector_groups for selector in selectors)
 
 
 def _resource_selectors(manifest: dict, bundle_tests: bool) -> list[tuple[str, tuple[str, ...], str]]:
@@ -208,8 +208,8 @@ def _resource_selectors(manifest: dict, bundle_tests: bool) -> list[tuple[str, t
         # `shlex.split` rather than `str.split`: the command is a shell string with the selector
         # quoted, and this is exactly how the notebook runner recovers the original argv value — so
         # tokenising the same way also proves that round-trip.
-        command = shlex.split(task['dbt_task']['commands'][-1])
-        selectors.append((task['task_key'], _command_selectors(command), command[1]))
+        command = shlex.split(task["dbt_task"]["commands"][-1])
+        selectors.append((task["task_key"], _command_selectors(command), command[1]))
     return selectors
 
 
@@ -221,14 +221,14 @@ def _task_key_to_unique_id(manifest: dict, bundle_tests: bool) -> dict[str, str]
     parsing the selector. Bundled task keys map to their parent resource here; their exact member sets
     are checked separately by `_bundled_test_ids_by_task_key`.
     """
-    nodes = _enabled_entries(manifest.get('nodes', {}))
-    unit_tests = _enabled_entries(manifest.get('unit_tests', {}))
+    nodes = _enabled_entries(manifest.get("nodes", {}))
+    unit_tests = _enabled_entries(manifest.get("unit_tests", {}))
     bundle_members = _bundled_test_membership(manifest) if bundle_tests else {}
     bundled_test_ids = {test_id for test_ids in bundle_members.values() for test_id in test_ids}
 
     task_ids = []
     for full_name, info in nodes.items():
-        if info.get('resource_type') in {'model', 'seed', 'snapshot', 'test'} and (
+        if info.get("resource_type") in {"model", "seed", "snapshot", "test"} and (
             not bundle_tests or full_name not in bundled_test_ids
         ):
             task_ids.append(full_name)
@@ -249,35 +249,35 @@ def _task_key_to_unique_id(manifest: dict, bundle_tests: bool) -> dict[str, str]
 def _enabled_entries(entries: dict) -> dict:
     """Returns the manifest entries dbt can select."""
     return {
-        full_name: info for full_name, info in entries.items() if (info.get('config') or {}).get('enabled') is not False
+        full_name: info for full_name, info in entries.items() if (info.get("config") or {}).get("enabled") is not False
     }
 
 
 def _unit_test_model_id(unit_test_info: dict) -> str | None:
     """Returns the model id dbt resolved for a unit test."""
-    for dep in unit_test_info.get('depends_on', {}).get('nodes', []):
-        if dep.startswith('model.'):
+    for dep in unit_test_info.get("depends_on", {}).get("nodes", []):
+        if dep.startswith("model."):
             return dep
-    model = unit_test_info.get('model')
-    package = unit_test_info.get('package_name')
-    return f'model.{package}.{model}' if model and package else None
+    model = unit_test_info.get("model")
+    package = unit_test_info.get("package_name")
+    return f"model.{package}.{model}" if model and package else None
 
 
 def _bundled_test_membership(manifest: dict) -> dict[str, set[str]]:
     """Groups enabled single-resource data and unit test ids by their exact bundle resource."""
-    nodes = _enabled_entries(manifest.get('nodes', {}))
-    sources = _enabled_entries(manifest.get('sources', {}))
-    unit_tests = _enabled_entries(manifest.get('unit_tests', {}))
+    nodes = _enabled_entries(manifest.get("nodes", {}))
+    sources = _enabled_entries(manifest.get("sources", {}))
+    unit_tests = _enabled_entries(manifest.get("unit_tests", {}))
     resources = nodes.keys() | sources.keys()
     membership: dict[str, set[str]] = {}
 
     for test_id, info in nodes.items():
-        if info.get('resource_type') != 'test':
+        if info.get("resource_type") != "test":
             continue
         parents = {
             dep
-            for dep in info.get('depends_on', {}).get('nodes', [])
-            if dep.startswith(('model.', 'seed.', 'snapshot.', 'source.')) and dep in resources
+            for dep in info.get("depends_on", {}).get("nodes", [])
+            if dep.startswith(("model.", "seed.", "snapshot.", "source.")) and dep in resources
         }
         if len(parents) == 1:
             membership.setdefault(next(iter(parents)), set()).add(test_id)
@@ -298,20 +298,20 @@ def _bundled_test_ids_by_task_key(manifest: dict) -> dict[str, set[str]]:
     return {
         task_key: membership[resource_id]
         for task_key, resource_id in expected_by_key.items()
-        if resource_id in membership and task_key.endswith('_test')
+        if resource_id in membership and task_key.endswith("_test")
     }
 
 
 def _selected_by_bundled_commands(tmp_path: Path, task: dict) -> set[str]:
     """Replays every test command in a bundle with its final indirect-selection mode."""
     selected: set[str] = set()
-    test_commands = [command for command in task['dbt_task']['commands'] if command.startswith('dbt test ')]
-    assert test_commands, f'{task["task_key"]} has no dbt test command'
+    test_commands = [command for command in task["dbt_task"]["commands"] if command.startswith("dbt test ")]
+    assert test_commands, f"{task['task_key']} has no dbt test command"
     for raw_command in test_commands:
         command = shlex.split(raw_command)
         selectors = _command_selectors(command)
-        modes = [command[index + 1] for index, value in enumerate(command[:-1]) if value == '--indirect-selection']
-        assert modes, f'{task["task_key"]} does not pin indirect selection: {raw_command}'
+        modes = [command[index + 1] for index, value in enumerate(command[:-1]) if value == "--indirect-selection"]
+        assert modes, f"{task['task_key']} does not pin indirect selection: {raw_command}"
         selected.update(_selected_unique_ids(tmp_path, selectors, None, indirect_selection=modes[-1]))
     return selected
 
@@ -326,67 +326,67 @@ def _assert_each_task_selects_its_own_node(tmp_path: Path, manifest: dict, bundl
     expected_by_key = _task_key_to_unique_id(manifest, bundle_tests)
     bundled_by_key = _bundled_test_ids_by_task_key(manifest) if bundle_tests else {}
     unmapped = []
-    selectable = {**manifest.get('nodes', {}), **manifest.get('unit_tests', {}), **manifest.get('sources', {})}
+    selectable = {**manifest.get("nodes", {}), **manifest.get("unit_tests", {}), **manifest.get("sources", {})}
     for task in create_dbt_factory(bundle_tests=bundle_tests).create_tasks(manifest):
-        task_key = task['task_key']
+        task_key = task["task_key"]
         if task_key in bundled_by_key:
             bundle_selection = _selected_by_bundled_commands(tmp_path, task)
             expected = bundled_by_key[task_key]
-            assert (
-                bundle_selection == expected
-            ), f'{task_key} runs {sorted(bundle_selection)}, expected exact bundle membership {sorted(expected)}'
+            assert bundle_selection == expected, (
+                f"{task_key} runs {sorted(bundle_selection)}, expected exact bundle membership {sorted(expected)}"
+            )
             continue
 
         unique_id = expected_by_key.get(task_key)
         if unique_id is None:
             unmapped.append(task_key)
             continue
-        command = shlex.split(task['dbt_task']['commands'][-1])
+        command = shlex.split(task["dbt_task"]["commands"][-1])
         select = _command_selectors(command)
         # Compare against the *manifest unique id*, not the name `dbt ls` displays. Two generic tests can
         # share a display name while separate files keep each selector individually addressable, so a
         # name-based assertion would be satisfied by pointing task A at task B's node.
-        resource_type = selectable[unique_id]['resource_type']
-        indirect_selection = 'empty'
-        if resource_type in {'test', 'unit_test'}:
-            modes = [command[index + 1] for index, value in enumerate(command[:-1]) if value == '--indirect-selection']
+        resource_type = selectable[unique_id]["resource_type"]
+        indirect_selection = "empty"
+        if resource_type in {"test", "unit_test"}:
+            modes = [command[index + 1] for index, value in enumerate(command[:-1]) if value == "--indirect-selection"]
             indirect_selection = modes[-1]
         node_selection = _selected_unique_ids(tmp_path, select, None, indirect_selection=indirect_selection)
         assert node_selection == (unique_id,), (
-            f'{task_key} selects {node_selection} via {select!r}, expected exactly ({unique_id!r},) — '
-            f'the node it is named for'
+            f"{task_key} selects {node_selection} via {select!r}, expected exactly ({unique_id!r},) — "
+            f"the node it is named for"
         )
-    assert not unmapped, f'no expected node known for {unmapped}; the key mapping has drifted'
+    assert not unmapped, f"no expected node known for {unmapped}; the key mapping has drifted"
 
 
 # Layouts that have actually broken selector generation in this project.
 REGRESSION_LAYOUTS = {
-    'sibling-named-directory': {
-        'marts/orders.sql': MODEL_SQL,
-        'marts/orders/items.sql': MODEL_SQL,
+    "sibling-named-directory": {
+        "marts/orders.sql": MODEL_SQL,
+        "marts/orders/items.sql": MODEL_SQL,
     },
-    'root-level-ancestor': {
-        'orders.sql': MODEL_SQL,
-        'orders/items.sql': MODEL_SQL,
+    "root-level-ancestor": {
+        "orders.sql": MODEL_SQL,
+        "orders/items.sql": MODEL_SQL,
     },
-    'dotted-name-collides': {
-        'marts/orders.sql': MODEL_SQL,
-        'marts/orders.items.sql': MODEL_SQL,
+    "dotted-name-collides": {
+        "marts/orders.sql": MODEL_SQL,
+        "marts/orders.items.sql": MODEL_SQL,
     },
-    'dotted-name-equals-nested-fqn': {
-        'marts/orders.items.sql': MODEL_SQL,
-        'marts/orders/items.sql': MODEL_SQL,
+    "dotted-name-equals-nested-fqn": {
+        "marts/orders.items.sql": MODEL_SQL,
+        "marts/orders/items.sql": MODEL_SQL,
     },
-    'deeply-nested': {
-        'a.sql': MODEL_SQL,
-        'a/b.sql': MODEL_SQL,
-        'a/b/c.sql': MODEL_SQL,
+    "deeply-nested": {
+        "a.sql": MODEL_SQL,
+        "a/b.sql": MODEL_SQL,
+        "a/b/c.sql": MODEL_SQL,
     },
 }
 
 
-@pytest.mark.parametrize('layout_name', sorted(REGRESSION_LAYOUTS))
-@pytest.mark.parametrize('bundle_tests', [False, True], ids=['per-test', 'bundled'])
+@pytest.mark.parametrize("layout_name", sorted(REGRESSION_LAYOUTS))
+@pytest.mark.parametrize("bundle_tests", [False, True], ids=["per-test", "bundled"])
 def test_regression_layouts_select_exactly_one_node(tmp_path, layout_name, bundle_tests):
     """Each resource task must build exactly the node it is named for, in both modes."""
     _write_project(tmp_path, REGRESSION_LAYOUTS[layout_name])
@@ -401,32 +401,32 @@ def test_bundled_test_task_unions_only_its_own_resources_tests(tmp_path):
     """
     _write_project(
         tmp_path,
-        {'marts/orders.sql': MODEL_SQL, 'marts/orders/items.sql': MODEL_SQL},
+        {"marts/orders.sql": MODEL_SQL, "marts/orders/items.sql": MODEL_SQL},
         schema_yml=(
-            'models:\n'
-            '  - name: orders\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '        data_tests: [unique, not_null]\n'
-            '  - name: items\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '        data_tests: [unique]\n'
+            "models:\n"
+            "  - name: orders\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        data_tests: [unique, not_null]\n"
+            "  - name: items\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        data_tests: [unique]\n"
         ),
     )
     manifest = _parse(tmp_path)
 
     selectors = {
-        key: select for key, select, verb in _resource_selectors(manifest, bundle_tests=True) if verb == 'test'
+        key: select for key, select, verb in _resource_selectors(manifest, bundle_tests=True) if verb == "test"
     }
-    orders_select = selectors['orders_test']
-    selected = _selected_ids(tmp_path, orders_select, resource_type=None, indirect_selection='empty')
+    orders_select = selectors["orders_test"]
+    selected = _selected_ids(tmp_path, orders_select, resource_type=None, indirect_selection="empty")
 
     # A schema test's fqn is [package, <test name>] — the models/ subdirectory is not part of it.
-    assert 'probe.unique_items_id' not in selected, f'orders_test included the sibling model tests: {selected}'
-    assert 'probe.unique_orders_id' in selected
-    assert 'probe.not_null_orders_id' in selected
-    assert 'probe.marts.orders.items' not in selected, f'orders_test selected the sibling model: {selected}'
+    assert "probe.unique_items_id" not in selected, f"orders_test included the sibling model tests: {selected}"
+    assert "probe.unique_orders_id" in selected
+    assert "probe.not_null_orders_id" in selected
+    assert "probe.marts.orders.items" not in selected, f"orders_test selected the sibling model: {selected}"
 
 
 def test_tests_sharing_a_schema_file_are_separated_by_test_name(tmp_path):
@@ -436,28 +436,28 @@ def test_tests_sharing_a_schema_file_are_separated_by_test_name(tmp_path):
     """
     _write_project(
         tmp_path,
-        {'my tests/a.sql': MODEL_SQL, 'my tests/b.sql': MODEL_SQL},
+        {"my tests/a.sql": MODEL_SQL, "my tests/b.sql": MODEL_SQL},
     )
-    (tmp_path / 'models' / 'my tests' / 'schema.yml').write_text(
-        'models:\n'
-        '  - name: a\n'
-        '    columns:\n'
-        '      - name: id\n'
-        '        data_tests: [not_null]\n'
-        '  - name: b\n'
-        '    columns:\n'
-        '      - name: id\n'
-        '        data_tests: [unique]\n',
-        encoding='utf-8',
+    (tmp_path / "models" / "my tests" / "schema.yml").write_text(
+        "models:\n"
+        "  - name: a\n"
+        "    columns:\n"
+        "      - name: id\n"
+        "        data_tests: [not_null]\n"
+        "  - name: b\n"
+        "    columns:\n"
+        "      - name: id\n"
+        "        data_tests: [unique]\n",
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
 
     selectors = {key: select for key, select, verb in _resource_selectors(manifest, bundle_tests=False)}
     for task_key, select in selectors.items():
-        if not task_key.endswith('_test'):
+        if not task_key.endswith("_test"):
             continue
-        selected = _selected_ids(tmp_path, select, 'test', indirect=False)
-        assert len(selected) == 1, f'{task_key} selects {selected} via {select!r}, expected exactly one test'
+        selected = _selected_ids(tmp_path, select, "test", indirect=False)
+        assert len(selected) == 1, f"{task_key} selects {selected} via {select!r}, expected exactly one test"
 
 
 def test_package_node_matched_by_package_stripped_fqn_is_still_exact(tmp_path):
@@ -469,8 +469,8 @@ def test_package_node_matched_by_package_stripped_fqn_is_still_exact(tmp_path):
     """
     _write_project(
         tmp_path,
-        {'alpha.sql': MODEL_SQL},
-        package_model_paths={'probe/alpha.sql': MODEL_SQL, 'probe/alpha/nested.sql': MODEL_SQL},
+        {"alpha.sql": MODEL_SQL},
+        package_model_paths={"probe/alpha.sql": MODEL_SQL, "probe/alpha/nested.sql": MODEL_SQL},
     )
     manifest = _parse(tmp_path)
 
@@ -478,10 +478,10 @@ def test_package_node_matched_by_package_stripped_fqn_is_still_exact(tmp_path):
 
 
 @pytest.mark.parametrize(
-    ('file_name', 'note'),
+    ("file_name", "note"),
     [
-        pytest.param('+leading.sql', 'an operator inside a segment is harmless', id='embedded-operator'),
-        pytest.param("customer's.sql", 'a quote breaks shlex in the notebook runner', id='apostrophe'),
+        pytest.param("+leading.sql", "an operator inside a segment is harmless", id="embedded-operator"),
+        pytest.param("customer's.sql", "a quote breaks shlex in the notebook runner", id="apostrophe"),
     ],
 )
 def test_awkward_file_names_still_resolve_to_one_node(tmp_path, file_name, note):
@@ -494,14 +494,14 @@ def test_awkward_file_names_still_resolve_to_one_node(tmp_path, file_name, note)
     `test_a_file_name_alone_is_not_enough_to_address_a_resource`.
     """
     assert note
-    _write_project(tmp_path, {file_name: MODEL_SQL, 'orders.sql': MODEL_SQL})
+    _write_project(tmp_path, {file_name: MODEL_SQL, "orders.sql": MODEL_SQL})
     manifest = _parse(tmp_path)
 
     for task_key, select, verb in _resource_selectors(manifest, bundle_tests=False):
-        if verb != 'run':
+        if verb != "run":
             continue
-        selected = _selected_ids(tmp_path, select, 'model', indirect=False)
-        assert len(selected) == 1, f'{task_key} selects {selected} via {select!r}, expected exactly one node'
+        selected = _selected_ids(tmp_path, select, "model", indirect=False)
+        assert len(selected) == 1, f"{task_key} selects {selected} via {select!r}, expected exactly one node"
 
 
 def test_singular_test_sharing_a_models_fqn_is_addressable_under_empty(tmp_path):
@@ -517,105 +517,105 @@ def test_singular_test_sharing_a_models_fqn_is_addressable_under_empty(tmp_path)
     """
     _write_project(
         tmp_path,
-        {'beta.sql': MODEL_SQL, 'gamma.sql': MODEL_SQL},
+        {"beta.sql": MODEL_SQL, "gamma.sql": MODEL_SQL},
         schema_yml=(
-            'models:\n'
-            '  - name: beta\n    columns:\n      - name: id\n        data_tests: [not_null]\n'
-            '  - name: gamma\n    columns:\n      - name: id\n        data_tests: [not_null]\n'
+            "models:\n"
+            "  - name: beta\n    columns:\n      - name: id\n        data_tests: [not_null]\n"
+            "  - name: gamma\n    columns:\n      - name: id\n        data_tests: [not_null]\n"
         ),
     )
-    tests_dir = tmp_path / 'tests'
+    tests_dir = tmp_path / "tests"
     tests_dir.mkdir(parents=True, exist_ok=True)
-    (tests_dir / 'beta.sql').write_text("select * from {{ ref('gamma') }} where id is null\n", encoding='utf-8')
+    (tests_dir / "beta.sql").write_text("select * from {{ ref('gamma') }} where id is null\n", encoding="utf-8")
     manifest = _parse(tmp_path)
 
-    leaky = 'fqn:probe.beta,package:probe,file:beta.sql,resource_type:test'
-    assert len(_selected_unique_ids(tmp_path, leaky, None)) == 2, 'eager no longer leaks; revisit this test'
+    leaky = "fqn:probe.beta,package:probe,file:beta.sql,resource_type:test"
+    assert len(_selected_unique_ids(tmp_path, leaky, None)) == 2, "eager no longer leaks; revisit this test"
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
 
 def test_bundled_selector_runs_only_tests_attached_to_its_resource(tmp_path: Path) -> None:
     _write_project(
         tmp_path,
-        {'beta.sql': MODEL_SQL, 'gamma.sql': MODEL_SQL},
+        {"beta.sql": MODEL_SQL, "gamma.sql": MODEL_SQL},
         schema_yml=(
-            'models:\n'
-            '  - name: beta\n    columns:\n      - name: id\n        data_tests: [not_null]\n'
-            '  - name: gamma\n    columns:\n      - name: id\n        data_tests: [not_null]\n'
+            "models:\n"
+            "  - name: beta\n    columns:\n      - name: id\n        data_tests: [not_null]\n"
+            "  - name: gamma\n    columns:\n      - name: id\n        data_tests: [not_null]\n"
         ),
     )
-    tests_dir = tmp_path / 'tests'
+    tests_dir = tmp_path / "tests"
     tests_dir.mkdir(parents=True, exist_ok=True)
-    (tests_dir / 'beta.sql').write_text("select * from {{ ref('gamma') }} where id is null\n", encoding='utf-8')
+    (tests_dir / "beta.sql").write_text("select * from {{ ref('gamma') }} where id is null\n", encoding="utf-8")
     manifest = _parse(tmp_path)
 
     expected_by_parent: dict[str, set[str]] = {}
-    for unique_id, info in manifest['nodes'].items():
-        if info['resource_type'] != 'test':
+    for unique_id, info in manifest["nodes"].items():
+        if info["resource_type"] != "test":
             continue
-        model_parents = {dep for dep in info['depends_on']['nodes'] if dep.startswith('model.')}
+        model_parents = {dep for dep in info["depends_on"]["nodes"] if dep.startswith("model.")}
         if len(model_parents) == 1:
             expected_by_parent.setdefault(next(iter(model_parents)), set()).add(unique_id)
 
-    tasks = {task['task_key']: task for task in create_dbt_factory(bundle_tests=True).create_tasks(manifest)}
-    for model_name in ('beta', 'gamma'):
+    tasks = {task["task_key"]: task for task in create_dbt_factory(bundle_tests=True).create_tasks(manifest)}
+    for model_name in ("beta", "gamma"):
         commands = []
-        for raw_command in tasks[f'{model_name}_test']['dbt_task']['commands']:
-            if raw_command.startswith('dbt test '):
+        for raw_command in tasks[f"{model_name}_test"]["dbt_task"]["commands"]:
+            if raw_command.startswith("dbt test "):
                 commands.append(shlex.split(raw_command))
         selected: set[str] = set()
         for command in commands:
             select = _command_selectors(command)
-            assert list(select) == sorted(select), f'non-deterministic bundled union: {select}'
+            assert list(select) == sorted(select), f"non-deterministic bundled union: {select}"
             result = _dbt(
                 tmp_path,
-                'ls',
-                '--quiet',
+                "ls",
+                "--quiet",
                 *command[2:],
-                '--resource-type',
-                'test',
-                '--output',
-                'json',
-                '--output-keys',
-                'unique_id',
+                "--resource-type",
+                "test",
+                "--output",
+                "json",
+                "--output-keys",
+                "unique_id",
             )
-            assert result.success, f'dbt ls failed for bundled {model_name!r} selector: {result.exception}'
+            assert result.success, f"dbt ls failed for bundled {model_name!r} selector: {result.exception}"
             assert isinstance(result.result, list)
-            selected.update(json.loads(entry)['unique_id'] for entry in result.result)
-        assert selected == expected_by_parent[f'model.probe.{model_name}']
+            selected.update(json.loads(entry)["unique_id"] for entry in result.result)
+        assert selected == expected_by_parent[f"model.probe.{model_name}"]
 
 
 def test_bundled_selector_unions_are_exact_in_empty_and_cautious_modes(tmp_path: Path) -> None:
     _write_project(
         tmp_path,
-        {'alpha.sql': MODEL_SQL, 'beta.sql': MODEL_SQL},
+        {"alpha.sql": MODEL_SQL, "beta.sql": MODEL_SQL},
         schema_yml=(
-            'models:\n'
-            '  - name: alpha\n    columns:\n      - name: id\n        data_tests:\n'
-            '          - unique\n          - not_null: {name: check}\n'
-            '  - name: beta\n    columns:\n      - name: id\n        data_tests:\n'
-            '          - not_null: {name: check.nested}\n'
+            "models:\n"
+            "  - name: alpha\n    columns:\n      - name: id\n        data_tests:\n"
+            "          - unique\n          - not_null: {name: check}\n"
+            "  - name: beta\n    columns:\n      - name: id\n        data_tests:\n"
+            "          - not_null: {name: check.nested}\n"
         ),
     )
     manifest = _parse(tmp_path)
-    alpha_id = 'model.probe.alpha'
+    alpha_id = "model.probe.alpha"
     expected = {
         unique_id
-        for unique_id, info in manifest['nodes'].items()
-        if info['resource_type'] == 'test' and alpha_id in info.get('depends_on', {}).get('nodes', [])
+        for unique_id, info in manifest["nodes"].items()
+        if info["resource_type"] == "test" and alpha_id in info.get("depends_on", {}).get("nodes", [])
     }
 
     alpha_task = next(
         task
         for task in create_dbt_factory(bundle_tests=True).create_tasks(manifest)
-        if task['task_key'] == 'alpha_test'
+        if task["task_key"] == "alpha_test"
     )
     commands = []
-    for raw_command in alpha_task['dbt_task']['commands']:
-        if raw_command.startswith('dbt test '):
+    for raw_command in alpha_task["dbt_task"]["commands"]:
+        if raw_command.startswith("dbt test "):
             commands.append(shlex.split(raw_command))
-    modes = [command[command.index('--indirect-selection') + 1] for command in commands]
-    assert modes == ['empty', 'cautious']
+    modes = [command[command.index("--indirect-selection") + 1] for command in commands]
+    assert modes == ["empty", "cautious"]
 
     selected: set[str] = set()
     for command in commands:
@@ -623,49 +623,49 @@ def test_bundled_selector_unions_are_exact_in_empty_and_cautious_modes(tmp_path:
         assert list(select) == sorted(select)
         result = _dbt(
             tmp_path,
-            'ls',
-            '--quiet',
+            "ls",
+            "--quiet",
             *command[2:],
-            '--resource-type',
-            'test',
-            '--output',
-            'json',
-            '--output-keys',
-            'unique_id',
+            "--resource-type",
+            "test",
+            "--output",
+            "json",
+            "--output-keys",
+            "unique_id",
         )
-        assert result.success, f'dbt ls failed for {select!r}: {result.exception}'
+        assert result.success, f"dbt ls failed for {select!r}: {result.exception}"
         assert isinstance(result.result, list)
-        selected.update(json.loads(entry)['unique_id'] for entry in result.result)
+        selected.update(json.loads(entry)["unique_id"] for entry in result.result)
     assert selected == expected
 
 
 def test_bundled_data_and_unit_tests_match_their_exact_manifest_membership(tmp_path):
     _write_project(
         tmp_path,
-        {'orders.sql': MODEL_SQL},
+        {"orders.sql": MODEL_SQL},
         schema_yml=(
-            'models:\n'
-            '  - name: orders\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '        data_tests: [not_null]\n'
-            'unit_tests:\n'
-            '  - name: totals\n'
-            '    model: orders\n'
-            '    given: []\n'
-            '    expect: {rows: [{id: 1}]}\n'
+            "models:\n"
+            "  - name: orders\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        data_tests: [not_null]\n"
+            "unit_tests:\n"
+            "  - name: totals\n"
+            "    model: orders\n"
+            "    given: []\n"
+            "    expect: {rows: [{id: 1}]}\n"
         ),
     )
     manifest = _parse(tmp_path)
 
-    data_test_ids = {unique_id for unique_id, info in manifest['nodes'].items() if info['resource_type'] == 'test'}
-    unit_test_ids = set(manifest.get('unit_tests', {}))
-    assert data_test_ids and unit_test_ids, 'dbt did not parse both test kinds'
+    data_test_ids = {unique_id for unique_id, info in manifest["nodes"].items() if info["resource_type"] == "test"}
+    unit_test_ids = set(manifest.get("unit_tests", {}))
+    assert data_test_ids and unit_test_ids, "dbt did not parse both test kinds"
 
     task = next(
         task
         for task in create_dbt_factory(bundle_tests=True).create_tasks(manifest)
-        if task['task_key'] == 'orders_test'
+        if task["task_key"] == "orders_test"
     )
     assert _selected_by_bundled_commands(tmp_path, task) == data_test_ids | unit_test_ids
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=True)
@@ -682,18 +682,18 @@ def test_every_bundled_selector_is_replayed_against_dbt(tmp_path):
     """
     _write_project(
         tmp_path,
-        {'orders.sql': MODEL_SQL},
+        {"orders.sql": MODEL_SQL},
         schema_yml=(
-            'models:\n'
-            '  - name: orders\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '        data_tests: [not_null]\n'
-            'unit_tests:\n'
-            '  - name: totals\n'
-            '    model: orders\n'
-            '    given: []\n'
-            '    expect: {rows: [{id: 1}]}\n'
+            "models:\n"
+            "  - name: orders\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        data_tests: [not_null]\n"
+            "unit_tests:\n"
+            "  - name: totals\n"
+            "    model: orders\n"
+            "    given: []\n"
+            "    expect: {rows: [{id: 1}]}\n"
         ),
     )
     manifest = _parse(tmp_path)
@@ -701,127 +701,127 @@ def test_every_bundled_selector_is_replayed_against_dbt(tmp_path):
     task = next(
         task
         for task in create_dbt_factory(bundle_tests=True).create_tasks(manifest)
-        if task['task_key'] == 'orders_test'
+        if task["task_key"] == "orders_test"
     )
-    command = shlex.split(next(c for c in task['dbt_task']['commands'] if c.startswith('dbt test ')))
+    command = shlex.split(next(c for c in task["dbt_task"]["commands"] if c.startswith("dbt test ")))
     selectors = _command_selectors(command)
-    assert len(selectors) > 1, 'the fixture no longer produces a multi-member bundle; this test proves nothing'
+    assert len(selectors) > 1, "the fixture no longer produces a multi-member bundle; this test proves nothing"
 
     # Each member must resolve to something on its own, and the union must exceed any single member —
     # which is false the moment the harness drops a selector.
-    per_selector = {selector: set(_selected_unique_ids(tmp_path, selector, None, 'empty')) for selector in selectors}
+    per_selector = {selector: set(_selected_unique_ids(tmp_path, selector, None, "empty")) for selector in selectors}
     for selector, resolved in per_selector.items():
-        assert resolved, f'{selector!r} resolves to nothing, so a dropped selector would go unnoticed'
-    union = set(_selected_unique_ids(tmp_path, selectors, None, 'empty'))
+        assert resolved, f"{selector!r} resolves to nothing, so a dropped selector would go unnoticed"
+    union = set(_selected_unique_ids(tmp_path, selectors, None, "empty"))
     assert union == set().union(*per_selector.values())
     for resolved in per_selector.values():
-        assert union > resolved, f'the union {sorted(union)} does not exceed the single member {sorted(resolved)}'
+        assert union > resolved, f"the union {sorted(union)} does not exceed the single member {sorted(resolved)}"
 
 
 def test_bundled_task_last_indirect_selection_option_controls_dbt(tmp_path):
     """dbt applies the final repeated indirect-selection option emitted by a bundled test task."""
     _write_project(
         tmp_path,
-        {'alpha.sql': MODEL_SQL, 'beta.sql': MODEL_SQL},
+        {"alpha.sql": MODEL_SQL, "beta.sql": MODEL_SQL},
         schema_yml=(
-            'models:\n'
-            '  - name: alpha\n    columns:\n      - name: id\n        data_tests: [not_null]\n'
-            '  - name: beta\n    columns:\n      - name: id\n'
+            "models:\n"
+            "  - name: alpha\n    columns:\n      - name: id\n        data_tests: [not_null]\n"
+            "  - name: beta\n    columns:\n      - name: id\n"
         ),
     )
-    tests_dir = tmp_path / 'tests'
+    tests_dir = tmp_path / "tests"
     tests_dir.mkdir(parents=True, exist_ok=True)
-    (tests_dir / 'alpha.sql').write_text("select * from {{ ref('beta') }} where id is null\n", encoding='utf-8')
+    (tests_dir / "alpha.sql").write_text("select * from {{ ref('beta') }} where id is null\n", encoding="utf-8")
     manifest = _parse(tmp_path)
     factory = create_dbt_factory(bundle_tests=True)
-    factory.task_factories['test'].dbt_options = '--target dev --indirect-selection eager'
-    task = next(task for task in factory.create_tasks(manifest) if task['task_key'] == 'beta_test')
-    command = shlex.split(task['dbt_task']['commands'][-1])
-    modes = [command[index + 1] for index, value in enumerate(command[:-1]) if value == '--indirect-selection']
-    assert modes == ['eager', 'empty']
+    factory.task_factories["test"].dbt_options = "--target dev --indirect-selection eager"
+    task = next(task for task in factory.create_tasks(manifest) if task["task_key"] == "beta_test")
+    command = shlex.split(task["dbt_task"]["commands"][-1])
+    modes = [command[index + 1] for index, value in enumerate(command[:-1]) if value == "--indirect-selection"]
+    assert modes == ["eager", "empty"]
 
-    select = command[command.index('--select') + 1]
-    eager = _selected_unique_ids(tmp_path, select, 'test', indirect_selection='eager')
-    empty = _selected_unique_ids(tmp_path, select, 'test', indirect_selection='empty')
+    select = command[command.index("--select") + 1]
+    eager = _selected_unique_ids(tmp_path, select, "test", indirect_selection="eager")
+    empty = _selected_unique_ids(tmp_path, select, "test", indirect_selection="empty")
     assert len(eager) == 2
     assert len(empty) == 1
 
     result = _dbt(
         tmp_path,
-        'ls',
-        '--quiet',
+        "ls",
+        "--quiet",
         *command[2:],
-        '--resource-type',
-        'test',
-        '--output',
-        'json',
-        '--output-keys',
-        'unique_id',
+        "--resource-type",
+        "test",
+        "--output",
+        "json",
+        "--output-keys",
+        "unique_id",
     )
-    assert result.success, f'dbt ls failed for emitted options: {result.exception}'
-    assert isinstance(result.result, list), f'expected dbt ls to return a list, got {type(result.result)}'
-    selected = tuple(sorted(json.loads(entry)['unique_id'] for entry in result.result))
+    assert result.success, f"dbt ls failed for emitted options: {result.exception}"
+    assert isinstance(result.result, list), f"expected dbt ls to return a list, got {type(result.result)}"
+    selected = tuple(sorted(json.loads(entry)["unique_id"] for entry in result.result))
     assert selected == empty
     assert selected != eager
 
 
 def test_selection_changing_extra_options_are_refused_after_live_dbt_proves_the_risk(tmp_path):
     """Repeated includes union and exclusions can silently widen or empty an otherwise exact selection."""
-    _write_project(tmp_path, {'alpha.sql': MODEL_SQL, 'beta.sql': MODEL_SQL})
+    _write_project(tmp_path, {"alpha.sql": MODEL_SQL, "beta.sql": MODEL_SQL})
     _parse(tmp_path)
 
     union = _dbt(
         tmp_path,
-        'ls',
-        '--quiet',
-        '--select',
-        'alpha',
-        '--select',
-        'beta',
-        '--output',
-        'json',
-        '--output-keys',
-        'unique_id',
+        "ls",
+        "--quiet",
+        "--select",
+        "alpha",
+        "--select",
+        "beta",
+        "--output",
+        "json",
+        "--output-keys",
+        "unique_id",
     )
-    assert union.success, f'dbt ls failed for repeated --select: {union.exception}'
+    assert union.success, f"dbt ls failed for repeated --select: {union.exception}"
     assert isinstance(union.result, list)
-    assert tuple(sorted(json.loads(entry)['unique_id'] for entry in union.result)) == (
-        'model.probe.alpha',
-        'model.probe.beta',
+    assert tuple(sorted(json.loads(entry)["unique_id"] for entry in union.result)) == (
+        "model.probe.alpha",
+        "model.probe.beta",
     )
 
     excluded = _dbt(
         tmp_path,
-        'ls',
-        '--quiet',
-        '--select',
-        'alpha',
-        '--exclude',
-        'alpha',
-        '--output',
-        'json',
-        '--output-keys',
-        'unique_id',
+        "ls",
+        "--quiet",
+        "--select",
+        "alpha",
+        "--exclude",
+        "alpha",
+        "--output",
+        "json",
+        "--output-keys",
+        "unique_id",
     )
-    assert excluded.success, f'dbt ls failed for --exclude: {excluded.exception}'
+    assert excluded.success, f"dbt ls failed for --exclude: {excluded.exception}"
     assert excluded.result == []
 
     clustered = _dbt(
         tmp_path,
-        'ls',
-        '--quiet',
-        '-xsbeta',
-        '--output',
-        'json',
-        '--output-keys',
-        'unique_id',
+        "ls",
+        "--quiet",
+        "-xsbeta",
+        "--output",
+        "json",
+        "--output-keys",
+        "unique_id",
     )
-    assert clustered.success, f'dbt ls failed for clustered -x -s: {clustered.exception}'
+    assert clustered.success, f"dbt ls failed for clustered -x -s: {clustered.exception}"
     assert isinstance(clustered.result, list)
-    assert tuple(json.loads(entry)['unique_id'] for entry in clustered.result) == ('model.probe.beta',)
+    assert tuple(json.loads(entry)["unique_id"] for entry in clustered.result) == ("model.probe.beta",)
 
-    for dbt_options in ('--select beta', '--exclude alpha', '-xsbeta'):
-        with pytest.raises(ValueError, match='selection'):
+    for dbt_options in ("--select beta", "--exclude alpha", "-xsbeta"):
+        with pytest.raises(ValueError, match="selection"):
             create_dbt_factory(dbt_options=dbt_options)
 
 
@@ -830,37 +830,37 @@ def test_parse_context_override_is_refused_after_live_dbt_proves_manifest_drift(
     _write_project(
         tmp_path,
         {
-            'alpha.sql': "{{ config(enabled=var('enable_alpha', true)) }}\nselect 1 as id\n",
-            'beta.sql': MODEL_SQL,
+            "alpha.sql": "{{ config(enabled=var('enable_alpha', true)) }}\nselect 1 as id\n",
+            "beta.sql": MODEL_SQL,
         },
     )
     manifest = _parse(tmp_path)
-    assert 'model.probe.alpha' in manifest['nodes']
+    assert "model.probe.alpha" in manifest["nodes"]
 
-    alpha_task = next(task for task in create_dbt_factory().create_tasks(manifest) if task['task_key'] == 'alpha_model')
-    command = shlex.split(alpha_task['dbt_task']['commands'][-1])
-    selector = command[command.index('--select') + 1]
-    assert _selected_unique_ids(tmp_path, selector, 'model') == ('model.probe.alpha',)
+    alpha_task = next(task for task in create_dbt_factory().create_tasks(manifest) if task["task_key"] == "alpha_model")
+    command = shlex.split(alpha_task["dbt_task"]["commands"][-1])
+    selector = command[command.index("--select") + 1]
+    assert _selected_unique_ids(tmp_path, selector, "model") == ("model.probe.alpha",)
 
     drifted = _dbt(
         tmp_path,
-        'ls',
-        '--quiet',
-        '--select',
+        "ls",
+        "--quiet",
+        "--select",
         selector,
-        '--vars',
-        '{enable_alpha: false}',
-        '--resource-type',
-        'model',
-        '--output',
-        'json',
-        '--output-keys',
-        'unique_id',
+        "--vars",
+        "{enable_alpha: false}",
+        "--resource-type",
+        "model",
+        "--output",
+        "json",
+        "--output-keys",
+        "unique_id",
     )
-    assert drifted.success, f'dbt ls failed for the vars override: {drifted.exception}'
+    assert drifted.success, f"dbt ls failed for the vars override: {drifted.exception}"
     assert drifted.result == []
 
-    with pytest.raises(ValueError, match='runtime parse context'):
+    with pytest.raises(ValueError, match="runtime parse context"):
         create_dbt_factory(dbt_options="--vars '{enable_alpha: false}'")
 
 
@@ -869,11 +869,11 @@ def test_duplicate_target_is_refused_after_live_dbt_proves_last_target_drift(tmp
     _write_project(
         tmp_path,
         {
-            'dev_only.sql': "{{ config(enabled=target.name == 'dev') }}\nselect 1 as id\n",
-            'shared.sql': MODEL_SQL,
+            "dev_only.sql": "{{ config(enabled=target.name == 'dev') }}\nselect 1 as id\n",
+            "shared.sql": MODEL_SQL,
         },
     )
-    (tmp_path / 'profiles.yml').write_text(
+    (tmp_path / "profiles.yml").write_text(
         PROFILES
         + """\
     prod:
@@ -883,92 +883,92 @@ def test_duplicate_target_is_refused_after_live_dbt_proves_last_target_drift(tmp
       token: dummy
       schema: default
 """,
-        encoding='utf-8',
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
-    assert 'model.probe.dev_only' in manifest['nodes']
+    assert "model.probe.dev_only" in manifest["nodes"]
 
     dev_only_task = next(
-        task for task in create_dbt_factory().create_tasks(manifest) if task['task_key'] == 'dev_only_model'
+        task for task in create_dbt_factory().create_tasks(manifest) if task["task_key"] == "dev_only_model"
     )
-    command = shlex.split(dev_only_task['dbt_task']['commands'][-1])
-    selector = command[command.index('--select') + 1]
-    assert _selected_unique_ids(tmp_path, selector, 'model') == ('model.probe.dev_only',)
+    command = shlex.split(dev_only_task["dbt_task"]["commands"][-1])
+    selector = command[command.index("--select") + 1]
+    assert _selected_unique_ids(tmp_path, selector, "model") == ("model.probe.dev_only",)
 
     drifted = _dbt(
         tmp_path,
-        'ls',
-        '--quiet',
-        '--target',
-        'dev',
-        '--target',
-        'prod',
-        '--select',
+        "ls",
+        "--quiet",
+        "--target",
+        "dev",
+        "--target",
+        "prod",
+        "--select",
         selector,
-        '--resource-type',
-        'model',
-        '--output',
-        'json',
-        '--output-keys',
-        'unique_id',
+        "--resource-type",
+        "model",
+        "--output",
+        "json",
+        "--output-keys",
+        "unique_id",
     )
-    assert drifted.success, f'dbt ls failed for repeated targets: {drifted.exception}'
+    assert drifted.success, f"dbt ls failed for repeated targets: {drifted.exception}"
     assert drifted.result == []
 
-    with pytest.raises(ValueError, match='at most one target'):
-        create_dbt_factory(dbt_options='--target dev --target prod')
+    with pytest.raises(ValueError, match="at most one target"):
+        create_dbt_factory(dbt_options="--target dev --target prod")
 
 
 @pytest.mark.parametrize(
-    ('target_args', 'dbt_options'),
+    ("target_args", "dbt_options"),
     [
-        pytest.param(('--target',), '--target', id='long-missing'),
-        pytest.param(('-t',), '-t', id='short-missing'),
-        pytest.param(('--target=',), '--target=', id='long-empty-attached'),
-        pytest.param(('--target', ''), "--target ''", id='long-empty-separate'),
-        pytest.param(('-t', ''), "-t ''", id='short-empty-separate'),
+        pytest.param(("--target",), "--target", id="long-missing"),
+        pytest.param(("-t",), "-t", id="short-missing"),
+        pytest.param(("--target=",), "--target=", id="long-empty-attached"),
+        pytest.param(("--target", ""), "--target ''", id="long-empty-separate"),
+        pytest.param(("-t", ""), "-t ''", id="short-empty-separate"),
     ],
 )
 def test_target_without_value_is_refused_after_live_dbt_proves_it_is_incomplete(tmp_path, target_args, dbt_options):
     """A controlled target token must include the value dbt requires."""
-    _write_project(tmp_path, {'intended.sql': MODEL_SQL})
+    _write_project(tmp_path, {"intended.sql": MODEL_SQL})
 
-    incomplete = _dbt(tmp_path, 'ls', '--quiet', *target_args)
-    assert not incomplete.success, f'dbt unexpectedly accepted {dbt_options!r} without a value'
+    incomplete = _dbt(tmp_path, "ls", "--quiet", *target_args)
+    assert not incomplete.success, f"dbt unexpectedly accepted {dbt_options!r} without a value"
 
-    with pytest.raises(ValueError, match='target requires a nonempty value'):
+    with pytest.raises(ValueError, match="target requires a nonempty value"):
         create_dbt_factory(dbt_options=dbt_options)
 
 
 def test_option_value_cannot_hide_a_second_selector_after_command_assembly(tmp_path, monkeypatch):
     """A value-taking global option cannot consume a target flag and expose its value as a selector."""
-    _write_project(tmp_path, {'intended.sql': MODEL_SQL, 'other.sql': MODEL_SQL})
+    _write_project(tmp_path, {"intended.sql": MODEL_SQL, "other.sql": MODEL_SQL})
     _parse(tmp_path)
 
     monkeypatch.chdir(tmp_path)
     widened = _dbt(
         tmp_path,
-        'ls',
-        '--quiet',
-        '--select',
-        'intended',
-        '--log-path',
-        '--target',
-        '-sother',
-        '--output',
-        'json',
-        '--output-keys',
-        'unique_id',
+        "ls",
+        "--quiet",
+        "--select",
+        "intended",
+        "--log-path",
+        "--target",
+        "-sother",
+        "--output",
+        "json",
+        "--output-keys",
+        "unique_id",
     )
-    assert widened.success, f'dbt rejected the full option sequence: {widened.exception}'
+    assert widened.success, f"dbt rejected the full option sequence: {widened.exception}"
     assert isinstance(widened.result, list)
-    assert tuple(sorted(json.loads(entry)['unique_id'] for entry in widened.result)) == (
-        'model.probe.intended',
-        'model.probe.other',
+    assert tuple(sorted(json.loads(entry)["unique_id"] for entry in widened.result)) == (
+        "model.probe.intended",
+        "model.probe.other",
     )
 
-    for dbt_options in ('--log-path --target -sother', '--log-path -t -sother'):
-        with pytest.raises(ValueError, match='at most one target'):
+    for dbt_options in ("--log-path --target -sother", "--log-path -t -sother"):
+        with pytest.raises(ValueError, match="at most one target"):
             create_dbt_factory(dbt_options=dbt_options)
 
 
@@ -978,10 +978,10 @@ def test_singular_test_not_sharing_a_models_fqn_is_kept(tmp_path):
     perfectly addressable and must still generate. Refusing every singular test would be far stricter
     than dbt requires.
     """
-    _write_project(tmp_path, {'beta.sql': MODEL_SQL})
-    tests_dir = tmp_path / 'tests'
+    _write_project(tmp_path, {"beta.sql": MODEL_SQL})
+    tests_dir = tmp_path / "tests"
     tests_dir.mkdir(parents=True, exist_ok=True)
-    (tests_dir / 'beta_is_sane.sql').write_text("select * from {{ ref('beta') }} where id is null\n", encoding='utf-8')
+    (tests_dir / "beta_is_sane.sql").write_text("select * from {{ ref('beta') }} where id is null\n", encoding="utf-8")
     manifest = _parse(tmp_path)
 
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
@@ -989,35 +989,35 @@ def test_singular_test_not_sharing_a_models_fqn_is_kept(tmp_path):
 
 def test_bundled_source_test_selector_is_exact(tmp_path):
     """A source bundle resolves exactly and gates a model that consumes the source."""
-    _write_project(tmp_path, {'downstream.sql': "select * from {{ source('raw', 'orders') }}\n"})
-    (tmp_path / 'models' / 'sources.yml').write_text(
-        'sources:\n'
-        '  - name: raw\n'
-        '    schema: default\n'
-        '    tables:\n'
-        '      - name: orders\n'
-        '        columns:\n'
-        '          - name: id\n'
-        '            data_tests: [not_null]\n',
-        encoding='utf-8',
+    _write_project(tmp_path, {"downstream.sql": "select * from {{ source('raw', 'orders') }}\n"})
+    (tmp_path / "models" / "sources.yml").write_text(
+        "sources:\n"
+        "  - name: raw\n"
+        "    schema: default\n"
+        "    tables:\n"
+        "      - name: orders\n"
+        "        columns:\n"
+        "          - name: id\n"
+        "            data_tests: [not_null]\n",
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
     tasks = create_dbt_factory(bundle_tests=True).create_tasks(manifest)
-    by_key = {task['task_key']: task for task in tasks}
+    by_key = {task["task_key"]: task for task in tasks}
 
-    selectors = [s for _, s, verb in _resource_selectors(manifest, bundle_tests=True) if verb == 'test']
-    assert selectors, 'expected a bundled source test task'
-    assert by_key['downstream_model']['depends_on'] == [{'task_key': 'raw_orders_test'}]
+    selectors = [s for _, s, verb in _resource_selectors(manifest, bundle_tests=True) if verb == "test"]
+    assert selectors, "expected a bundled source test task"
+    assert by_key["downstream_model"]["depends_on"] == [{"task_key": "raw_orders_test"}]
     assert not _has_source_selector(selectors)
     for select in selectors:
-        selected = _selected_ids(tmp_path, select, 'test', indirect_selection='empty')
-        assert len(selected) == 1, f'{select!r} selects {selected}, expected exactly one test'
+        selected = _selected_ids(tmp_path, select, "test", indirect_selection="empty")
+        assert len(selected) == 1, f"{select!r} selects {selected}, expected exactly one test"
 
 
 def test_bundled_seed_test_gates_snapshot_that_consumes_the_seed(tmp_path):
     _write_project(
         tmp_path,
-        {'placeholder.sql': MODEL_SQL},
+        {"placeholder.sql": MODEL_SQL},
         schema_yml="""seeds:
   - name: countries
     columns:
@@ -1025,26 +1025,26 @@ def test_bundled_seed_test_gates_snapshot_that_consumes_the_seed(tmp_path):
         data_tests: [not_null]
 """,
     )
-    seeds_dir = tmp_path / 'seeds'
+    seeds_dir = tmp_path / "seeds"
     seeds_dir.mkdir()
-    (seeds_dir / 'countries.csv').write_text('id,name\n1,France\n', encoding='utf-8')
-    snapshots_dir = tmp_path / 'snapshots'
+    (seeds_dir / "countries.csv").write_text("id,name\n1,France\n", encoding="utf-8")
+    snapshots_dir = tmp_path / "snapshots"
     snapshots_dir.mkdir()
-    (snapshots_dir / 'country_history.sql').write_text(
+    (snapshots_dir / "country_history.sql").write_text(
         """{% snapshot country_history %}
 {{ config(target_schema='snapshots', strategy='check', unique_key='id', check_cols=['name']) }}
 select * from {{ ref('countries') }}
 {% endsnapshot %}
 """,
-        encoding='utf-8',
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
 
     tasks = create_dbt_factory(bundle_tests=True).create_tasks(manifest)
-    by_key = {task['task_key']: task for task in tasks}
+    by_key = {task["task_key"]: task for task in tasks}
 
-    assert by_key['countries_test']['depends_on'] == [{'task_key': 'countries_seed'}]
-    assert by_key['country_history_snapshot']['depends_on'] == [{'task_key': 'countries_test'}]
+    assert by_key["countries_test"]["depends_on"] == [{"task_key": "countries_seed"}]
+    assert by_key["country_history_snapshot"]["depends_on"] == [{"task_key": "countries_test"}]
 
 
 def test_every_task_selector_resolves_to_one_node(tmp_path):
@@ -1059,25 +1059,25 @@ def test_every_task_selector_resolves_to_one_node(tmp_path):
     """
     _write_project(
         tmp_path,
-        {'marts/orders.sql': MODEL_SQL, 'marts/orders/items.sql': MODEL_SQL},
+        {"marts/orders.sql": MODEL_SQL, "marts/orders/items.sql": MODEL_SQL},
         schema_yml=(
-            'models:\n'
-            '  - name: orders\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '        data_tests: [unique, not_null]\n'
-            'unit_tests:\n'
-            '  - name: ut_orders\n'
-            '    model: orders\n'
-            '    given: []\n'
-            '    expect: {rows: [{id: 1}]}\n'
+            "models:\n"
+            "  - name: orders\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        data_tests: [unique, not_null]\n"
+            "unit_tests:\n"
+            "  - name: ut_orders\n"
+            "    model: orders\n"
+            "    given: []\n"
+            "    expect: {rows: [{id: 1}]}\n"
         ),
     )
     manifest = _parse(tmp_path)
 
     for task_key, select, _verb in _resource_selectors(manifest, bundle_tests=False):
-        selected = _selected_ids(tmp_path, select, resource_type=None, indirect_selection='empty')
-        assert len(selected) == 1, f'{task_key} selects {selected} via {select!r}, expected exactly one node'
+        selected = _selected_ids(tmp_path, select, resource_type=None, indirect_selection="empty")
+        assert len(selected) == 1, f"{task_key} selects {selected} via {select!r}, expected exactly one node"
 
 
 def test_same_type_tests_in_one_file_resolve_individually(tmp_path):
@@ -1086,29 +1086,29 @@ def test_same_type_tests_in_one_file_resolve_individually(tmp_path):
     `test_name:` cannot separate them. Under a spacey directory the fqn is unusable too, leaving the
     bare resource name as the only discriminator — verified here against dbt rather than asserted.
     """
-    _write_project(tmp_path, {'my tests/a.sql': MODEL_SQL, 'my tests/b.sql': MODEL_SQL})
-    (tmp_path / 'models' / 'my tests' / 'schema.yml').write_text(
-        'models:\n'
-        '  - name: a\n'
-        '    columns:\n'
-        '      - name: id\n'
-        '        data_tests: [not_null]\n'
-        '  - name: b\n'
-        '    columns:\n'
-        '      - name: id\n'
-        '        data_tests: [not_null]\n',
-        encoding='utf-8',
+    _write_project(tmp_path, {"my tests/a.sql": MODEL_SQL, "my tests/b.sql": MODEL_SQL})
+    (tmp_path / "models" / "my tests" / "schema.yml").write_text(
+        "models:\n"
+        "  - name: a\n"
+        "    columns:\n"
+        "      - name: id\n"
+        "        data_tests: [not_null]\n"
+        "  - name: b\n"
+        "    columns:\n"
+        "      - name: id\n"
+        "        data_tests: [not_null]\n",
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
 
     selectors = _resource_selectors(manifest, bundle_tests=False)
-    test_selectors = {key: select for key, select, verb in selectors if verb == 'test'}
-    assert len(set(test_selectors.values())) == len(
-        test_selectors
-    ), f'the two same-type tests share a selector: {test_selectors}'
+    test_selectors = {key: select for key, select, verb in selectors if verb == "test"}
+    assert len(set(test_selectors.values())) == len(test_selectors), (
+        f"the two same-type tests share a selector: {test_selectors}"
+    )
     for task_key, select in test_selectors.items():
-        selected = _selected_ids(tmp_path, select, 'test', indirect=False)
-        assert len(selected) == 1, f'{task_key} selects {selected} via {select!r}, expected exactly one test'
+        selected = _selected_ids(tmp_path, select, "test", indirect=False)
+        assert len(selected) == 1, f"{task_key} selects {selected} via {select!r}, expected exactly one test"
 
 
 def test_leading_numeric_graph_operator_in_a_name_is_addressable_under_an_explicit_fqn(tmp_path):
@@ -1125,25 +1125,25 @@ def test_leading_numeric_graph_operator_in_a_name_is_addressable_under_an_explic
     `test_a_file_name_alone_is_not_enough_to_address_a_resource` and, for sources,
     `test_source_with_a_trailing_graph_operator_is_refused`.
     """
-    _write_project(tmp_path, {'my dir/a.sql': MODEL_SQL, 'my dir/b.sql': MODEL_SQL})
-    (tmp_path / 'models' / 'my dir' / 'schema.yml').write_text(
-        'models:\n'
-        '  - name: a\n'
-        '    columns:\n'
-        '      - name: id\n'
-        '        data_tests:\n'
+    _write_project(tmp_path, {"my dir/a.sql": MODEL_SQL, "my dir/b.sql": MODEL_SQL})
+    (tmp_path / "models" / "my dir" / "schema.yml").write_text(
+        "models:\n"
+        "  - name: a\n"
+        "    columns:\n"
+        "      - name: id\n"
+        "        data_tests:\n"
         '          - not_null: {name: "2+check"}\n'
-        '  - name: b\n'
-        '    columns:\n'
-        '      - name: id\n'
-        '        data_tests: [not_null]\n',
-        encoding='utf-8',
+        "  - name: b\n"
+        "    columns:\n"
+        "      - name: id\n"
+        "        data_tests: [not_null]\n",
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
 
     # The bare value really is unusable — this is why the explicit method matters.
-    assert not _selected_unique_ids(tmp_path, '2+check', 'test')
-    assert _selected_unique_ids(tmp_path, 'fqn:2+check', 'test')
+    assert not _selected_unique_ids(tmp_path, "2+check", "test")
+    assert _selected_unique_ids(tmp_path, "fqn:2+check", "test")
 
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
@@ -1154,27 +1154,27 @@ def test_source_with_a_trailing_graph_operator_uses_an_exact_test_selector(tmp_p
     operator: `source:probe.raw.orders+1` matches nothing while `dbt test` still exits 0, so the
     source's tests would silently never run. Bundled mode instead selects the attached test node exactly.
     """
-    _write_project(tmp_path, {'downstream.sql': "select * from {{ source('raw','orders+1') }}\n"})
-    (tmp_path / 'models' / 'sources.yml').write_text(
-        'sources:\n'
-        '  - name: raw\n'
-        '    schema: default\n'
-        '    tables:\n'
+    _write_project(tmp_path, {"downstream.sql": "select * from {{ source('raw','orders+1') }}\n"})
+    (tmp_path / "models" / "sources.yml").write_text(
+        "sources:\n"
+        "  - name: raw\n"
+        "    schema: default\n"
+        "    tables:\n"
         '      - name: "orders+1"\n'
-        '        identifier: ord\n'
-        '        columns:\n'
-        '          - name: id\n'
-        '            data_tests: [not_null]\n',
-        encoding='utf-8',
+        "        identifier: ord\n"
+        "        columns:\n"
+        "          - name: id\n"
+        "            data_tests: [not_null]\n",
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
 
     # The selector we would otherwise have emitted matches nothing, and dbt still exits 0 for it.
-    assert not _selected_ids(tmp_path, 'source:probe.raw.orders+1', None, indirect=True)
+    assert not _selected_ids(tmp_path, "source:probe.raw.orders+1", None, indirect=True)
 
-    selectors = [select for _, select, verb in _resource_selectors(manifest, bundle_tests=True) if verb == 'test']
+    selectors = [select for _, select, verb in _resource_selectors(manifest, bundle_tests=True) if verb == "test"]
     assert selectors and not _has_source_selector(selectors)
-    assert _selected_unique_ids(tmp_path, selectors[0], 'test', indirect_selection='empty')
+    assert _selected_unique_ids(tmp_path, selectors[0], "test", indirect_selection="empty")
 
 
 def test_source_keeps_an_operator_away_from_the_boundary(tmp_path):
@@ -1182,89 +1182,89 @@ def test_source_keeps_an_operator_away_from_the_boundary(tmp_path):
     The mirror image: `2+ord` puts the operator mid-string, where dbt resolves it exactly. Refusing
     it would reject a working project, so the guard must apply to the boundary only.
     """
-    _write_project(tmp_path, {'downstream.sql': "select * from {{ source('raw','2+ord') }}\n"})
-    (tmp_path / 'models' / 'sources.yml').write_text(
-        'sources:\n'
-        '  - name: raw\n'
-        '    schema: default\n'
-        '    tables:\n'
+    _write_project(tmp_path, {"downstream.sql": "select * from {{ source('raw','2+ord') }}\n"})
+    (tmp_path / "models" / "sources.yml").write_text(
+        "sources:\n"
+        "  - name: raw\n"
+        "    schema: default\n"
+        "    tables:\n"
         '      - name: "2+ord"\n'
-        '        identifier: ord\n'
-        '        columns:\n'
-        '          - name: id\n'
-        '            data_tests: [not_null]\n',
-        encoding='utf-8',
+        "        identifier: ord\n"
+        "        columns:\n"
+        "          - name: id\n"
+        "            data_tests: [not_null]\n",
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
 
-    test_selectors = [s for _, s, verb in _resource_selectors(manifest, bundle_tests=True) if verb == 'test']
+    test_selectors = [s for _, s, verb in _resource_selectors(manifest, bundle_tests=True) if verb == "test"]
     assert test_selectors and not _has_source_selector(test_selectors)
     for select in test_selectors:
-        assert _selected_ids(tmp_path, select, 'test', indirect_selection='empty'), f'{select!r} matched nothing'
+        assert _selected_ids(tmp_path, select, "test", indirect_selection="empty"), f"{select!r} matched nothing"
 
 
 def test_literal_and_incomplete_braces_in_a_source_still_allow_an_exact_test_bundle(tmp_path):
     """Literal source braces do not enter the bundle when the attached test is directly addressable."""
-    _write_project(tmp_path, {'downstream.sql': MODEL_SQL})
-    (tmp_path / 'models' / 'sources.yml').write_text(
-        'sources:\n'
+    _write_project(tmp_path, {"downstream.sql": MODEL_SQL})
+    (tmp_path / "models" / "sources.yml").write_text(
+        "sources:\n"
         "  - name: \"raw{{ '{' }}{{ '{' }}draft\"\n"
-        '    schema: default\n'
-        '    tables:\n'
+        "    schema: default\n"
+        "    tables:\n"
         '      - name: "orders{v1}"\n'
-        '        identifier: ord\n'
-        '        columns:\n'
-        '          - name: id\n'
-        '            data_tests: [not_null]\n',
-        encoding='utf-8',
+        "        identifier: ord\n"
+        "        columns:\n"
+        "          - name: id\n"
+        "            data_tests: [not_null]\n",
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
 
-    source_id, source = next(iter(manifest['sources'].items()))
-    assert source_id == 'source.probe.raw{{draft.orders{v1}'
-    assert source['source_name'] == 'raw{{draft'
-    assert source['name'] == 'orders{v1}'
+    source_id, source = next(iter(manifest["sources"].items()))
+    assert source_id == "source.probe.raw{{draft.orders{v1}"
+    assert source["source_name"] == "raw{{draft"
+    assert source["name"] == "orders{v1}"
 
-    source_select = 'source:probe.raw{{draft.orders{v1}'
-    assert _selected_unique_ids(tmp_path, source_select, 'source') == (source_id,)
+    source_select = "source:probe.raw{{draft.orders{v1}"
+    assert _selected_unique_ids(tmp_path, source_select, "source") == (source_id,)
     expected_tests = tuple(
         sorted(
             unique_id
-            for unique_id, info in manifest['nodes'].items()
-            if source_id in info.get('depends_on', {}).get('nodes', [])
+            for unique_id, info in manifest["nodes"].items()
+            if source_id in info.get("depends_on", {}).get("nodes", [])
         )
     )
     assert expected_tests
-    test_selectors = [select for _, select, verb in _resource_selectors(manifest, bundle_tests=True) if verb == 'test']
+    test_selectors = [select for _, select, verb in _resource_selectors(manifest, bundle_tests=True) if verb == "test"]
     assert test_selectors and not _has_source_selector(test_selectors)
-    assert _selected_unique_ids(tmp_path, test_selectors[0], 'test', indirect_selection='empty') == expected_tests
+    assert _selected_unique_ids(tmp_path, test_selectors[0], "test", indirect_selection="empty") == expected_tests
 
 
 def test_source_dynamic_reference_in_the_generated_test_name_is_refused(tmp_path):
     """dbt carries the source reference into the test name, so no safe direct selector survives."""
-    _write_project(tmp_path, {'downstream.sql': MODEL_SQL})
-    (tmp_path / 'models' / 'sources.yml').write_text(
-        'sources:\n'
+    _write_project(tmp_path, {"downstream.sql": MODEL_SQL})
+    (tmp_path / "models" / "sources.yml").write_text(
+        "sources:\n"
         "  - name: \"{{ '{' }}{{ '{' }}job\"\n"
-        '    schema: default\n'
-        '    tables:\n'
+        "    schema: default\n"
+        "    tables:\n"
         "      - name: \"id{{ '}' }}{{ '}' }}\"\n"
-        '        identifier: ord\n'
-        '        columns:\n'
-        '          - name: id\n'
-        '            data_tests: [not_null]\n',
-        encoding='utf-8',
+        "        identifier: ord\n"
+        "        columns:\n"
+        "          - name: id\n"
+        "            data_tests: [not_null]\n",
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
 
-    source_id, source = next(iter(manifest['sources'].items()))
-    assert source_id == 'source.probe.{{job.id}}'
-    assert source['source_name'] == '{{job'
-    assert source['name'] == 'id}}'
-    assembled = 'source:probe.{{job.id}}'
-    assert _selected_unique_ids(tmp_path, assembled, 'source') == (source_id,)
+    source_id, source = next(iter(manifest["sources"].items()))
+    assert source_id == "source.probe.{{job.id}}"
+    assert source["source_name"] == "{{job"
+    assert source["name"] == "id}}"
+    assembled = "source:probe.{{job.id}}"
+    assert _selected_unique_ids(tmp_path, assembled, "source") == (source_id,)
 
-    with pytest.raises(ValueError, match='Cannot generate a task for'):
+    with pytest.raises(ValueError, match="Cannot generate a task for"):
         _resource_selectors(manifest, bundle_tests=True)
 
 
@@ -1276,26 +1276,26 @@ def test_tests_sharing_a_file_with_no_usable_name_are_refused(tmp_path):
 
     A bracketed custom test name kills both the fqn and the name (`[...]` is fnmatch syntax).
     """
-    _write_project(tmp_path, {'a.sql': MODEL_SQL, 'b.sql': MODEL_SQL})
-    (tmp_path / 'models' / 'schema.yml').write_text(
-        'models:\n'
-        '  - name: a\n'
-        '    columns:\n'
-        '      - name: id\n'
-        '        data_tests:\n'
+    _write_project(tmp_path, {"a.sql": MODEL_SQL, "b.sql": MODEL_SQL})
+    (tmp_path / "models" / "schema.yml").write_text(
+        "models:\n"
+        "  - name: a\n"
+        "    columns:\n"
+        "      - name: id\n"
+        "        data_tests:\n"
         '          - not_null: {name: "check[a]id"}\n'
-        '  - name: b\n'
-        '    columns:\n'
-        '      - name: id\n'
-        '        data_tests: [not_null]\n',
-        encoding='utf-8',
+        "  - name: b\n"
+        "    columns:\n"
+        "      - name: id\n"
+        "        data_tests: [not_null]\n",
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
 
     # What the un-guarded selector resolved to: two tests, so two tasks would both run not_null_b_id.
-    assert len(_selected_ids(tmp_path, 'package:probe,file:schema.yml,test_name:not_null', 'test', indirect=False)) == 2
+    assert len(_selected_ids(tmp_path, "package:probe,file:schema.yml,test_name:not_null", "test", indirect=False)) == 2
 
-    with pytest.raises(ValueError, match='Cannot generate a task for'):
+    with pytest.raises(ValueError, match="Cannot generate a task for"):
         _resource_selectors(manifest, bundle_tests=False)
 
 
@@ -1313,13 +1313,13 @@ def test_a_file_name_alone_is_not_enough_to_address_a_resource(tmp_path):
     end in `+1`, which dbt reads as child depth. `package:probe,file:orders+1.sql` does resolve to
     exactly one node — verified here — so this refusal is deliberately stricter than dbt requires.
     """
-    _write_project(tmp_path, {'orders+1.sql': MODEL_SQL, 'orders.sql': MODEL_SQL})
+    _write_project(tmp_path, {"orders+1.sql": MODEL_SQL, "orders.sql": MODEL_SQL})
     manifest = _parse(tmp_path)
 
     # dbt would accept it: the selector we no longer emit is exact.
-    assert _selected_ids(tmp_path, 'package:probe,file:orders+1.sql', 'model') == ('probe.orders+1',)
+    assert _selected_ids(tmp_path, "package:probe,file:orders+1.sql", "model") == ("probe.orders+1",)
 
-    with pytest.raises(ValueError, match='Cannot generate a task for'):
+    with pytest.raises(ValueError, match="Cannot generate a task for"):
         _resource_selectors(manifest, bundle_tests=False)
 
 
@@ -1330,19 +1330,19 @@ def test_a_usable_name_still_rescues_an_unusable_fqn(tmp_path):
     fqn's leaf, so these projects keep working. Refusing them too would reject any project with a
     space in a directory name.
     """
-    _write_project(tmp_path, {'my dir/orders.sql': MODEL_SQL, 'my dir/items.sql': MODEL_SQL})
+    _write_project(tmp_path, {"my dir/orders.sql": MODEL_SQL, "my dir/items.sql": MODEL_SQL})
     manifest = _parse(tmp_path)
 
     for task_key, select, _verb in _resource_selectors(manifest, bundle_tests=False):
-        selected = _selected_ids(tmp_path, select, 'model')
-        assert len(selected) == 1, f'{task_key} selects {selected} via {select!r}, expected exactly one node'
+        selected = _selected_ids(tmp_path, select, "model")
+        assert len(selected) == 1, f"{task_key} selects {selected} via {select!r}, expected exactly one node"
 
 
 @pytest.mark.parametrize(
-    ('source_name', 'table'),
+    ("source_name", "table"),
     [
-        pytest.param('raw.v1', 'ord', id='dotted-source-name'),
-        pytest.param('raw', 'ord.v1', id='dotted-table-name'),
+        pytest.param("raw.v1", "ord", id="dotted-source-name"),
+        pytest.param("raw", "ord.v1", id="dotted-table-name"),
     ],
 )
 def test_dotted_source_part_uses_an_exact_test_selector(tmp_path, source_name, table):
@@ -1353,28 +1353,28 @@ def test_dotted_source_part_uses_an_exact_test_selector(tmp_path, source_name, t
 
     Asserted from both ends: dbt rejects the naive string, while the emitted selector resolves the test.
     """
-    _write_project(tmp_path, {'downstream.sql': f"select * from {{{{ source('{source_name}','{table}') }}}}\n"})
-    (tmp_path / 'models' / 'sources.yml').write_text(
-        f'sources:\n'
+    _write_project(tmp_path, {"downstream.sql": f"select * from {{{{ source('{source_name}','{table}') }}}}\n"})
+    (tmp_path / "models" / "sources.yml").write_text(
+        f"sources:\n"
         f'  - name: "{source_name}"\n'
-        f'    schema: default\n'
-        f'    tables:\n'
+        f"    schema: default\n"
+        f"    tables:\n"
         f'      - name: "{table}"\n'
-        f'        identifier: ord\n'
-        f'        columns:\n'
-        f'          - name: id\n'
-        f'            data_tests: [not_null]\n',
-        encoding='utf-8',
+        f"        identifier: ord\n"
+        f"        columns:\n"
+        f"          - name: id\n"
+        f"            data_tests: [not_null]\n",
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
 
     # dbt's own verdict on the selector we would otherwise have emitted.
-    rejected = _dbt(tmp_path, 'ls', '--quiet', '--select', f'source:probe.{source_name}.{table}')
-    assert not rejected.success, 'dbt accepted a four-part source selector; this test is no longer meaningful'
+    rejected = _dbt(tmp_path, "ls", "--quiet", "--select", f"source:probe.{source_name}.{table}")
+    assert not rejected.success, "dbt accepted a four-part source selector; this test is no longer meaningful"
 
-    selectors = [select for _, select, verb in _resource_selectors(manifest, bundle_tests=True) if verb == 'test']
+    selectors = [select for _, select, verb in _resource_selectors(manifest, bundle_tests=True) if verb == "test"]
     assert selectors and not _has_source_selector(selectors)
-    assert _selected_unique_ids(tmp_path, selectors[0], 'test', indirect_selection='empty')
+    assert _selected_unique_ids(tmp_path, selectors[0], "test", indirect_selection="empty")
 
 
 def test_disabled_node_left_in_the_manifest_gets_no_task(tmp_path):
@@ -1386,36 +1386,36 @@ def test_disabled_node_left_in_the_manifest_gets_no_task(tmp_path):
     """
     _write_project(
         tmp_path,
-        {'orders.sql': MODEL_SQL},
+        {"orders.sql": MODEL_SQL},
         schema_yml=(
-            'models:\n'
-            '  - name: orders\n'
-            '    latest_version: 2\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '        data_tests: [not_null]\n'
-            '    versions:\n'
-            '      - v: 1\n'
-            '      - v: 2\n'
+            "models:\n"
+            "  - name: orders\n"
+            "    latest_version: 2\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        data_tests: [not_null]\n"
+            "    versions:\n"
+            "      - v: 1\n"
+            "      - v: 2\n"
         ),
     )
     manifest = _parse(tmp_path)
 
     # Guard the fixture: if dbt stops leaking the disabled node, this test proves nothing.
-    disabled = [info for info in manifest['nodes'].values() if info.get('config', {}).get('enabled') is False]
-    assert disabled, 'dbt no longer leaves a disabled node in `nodes`; this test is no longer meaningful'
-    assert not _selected_ids(tmp_path, 'probe.not_null_orders_v1_id', 'test', indirect=False)
+    disabled = [info for info in manifest["nodes"].values() if info.get("config", {}).get("enabled") is False]
+    assert disabled, "dbt no longer leaves a disabled node in `nodes`; this test is no longer meaningful"
+    assert not _selected_ids(tmp_path, "probe.not_null_orders_v1_id", "test", indirect=False)
 
     for bundle_tests in (False, True):
         for task_key, select, _verb in _resource_selectors(manifest, bundle_tests):
-            selected = _selected_ids(tmp_path, select, resource_type=None, indirect_selection='empty')
-            assert selected, f'{task_key} selects nothing via {select!r}; the task would pass having done nothing'
+            selected = _selected_ids(tmp_path, select, resource_type=None, indirect_selection="empty")
+            assert selected, f"{task_key} selects nothing via {select!r}; the task would pass having done nothing"
 
 
 # Building blocks for the generative case: names that collide with directory names, names carrying a
 # dot, and nesting, which together reproduce every prefix hazard found so far.
-_NAME_POOL = ('orders', 'items', 'dim', 'orders.items', 'marts')
-_DIR_POOL = ('', 'marts/', 'orders/', 'marts/orders/')
+_NAME_POOL = ("orders", "items", "dim", "orders.items", "marts")
+_DIR_POOL = ("", "marts/", "orders/", "marts/orders/")
 
 
 def _random_layout(rng: random.Random) -> dict[str, str]:
@@ -1429,11 +1429,11 @@ def _random_layout(rng: random.Random) -> dict[str, str]:
         if name in used_names:
             continue
         used_names.add(name)
-        layout[f'{directory}{name}.sql'] = MODEL_SQL
+        layout[f"{directory}{name}.sql"] = MODEL_SQL
     return layout
 
 
-@pytest.mark.parametrize('seed', range(8))
+@pytest.mark.parametrize("seed", range(8))
 def test_generated_selectors_are_exact(tmp_path, seed):
     """
     The generative case. For a randomised layout, every resource task's selector must resolve to
@@ -1443,7 +1443,7 @@ def test_generated_selectors_are_exact(tmp_path, seed):
     rng = random.Random(seed)
     layout = _random_layout(rng)
     if len(layout) < 2:  # pragma: no cover - a degenerate draw carries no information
-        pytest.skip('layout collapsed to a single model')
+        pytest.skip("layout collapsed to a single model")
     _write_project(tmp_path, layout)
     manifest = _parse(tmp_path)
 
@@ -1472,14 +1472,14 @@ def test_random_layouts_are_not_degenerate(tmp_path):
         layout = _random_layout(random.Random(seed))
         sizes.append(len(layout))
     assert sum(1 for size in sizes if size >= 2) >= 6, (
-        f'the pools collapse too often to exercise prefix hazards: layout sizes {sizes}. '
-        'The generative test would be near-vacuous.'
+        f"the pools collapse too often to exercise prefix hazards: layout sizes {sizes}. "
+        "The generative test would be near-vacuous."
     )
 
     # And the pools really do produce the prefix hazards they exist for: a name that is another name's
     # parent directory, and a dotted name that flattens onto a nested fqn.
-    assert any('.' in name for name in _NAME_POOL), 'no dotted name; the flattening hazard is unreachable'
-    assert any(f'{name}/' in _DIR_POOL for name in _NAME_POOL), 'no name shared with a directory'
+    assert any("." in name for name in _NAME_POOL), "no dotted name; the flattening hazard is unreachable"
+    assert any(f"{name}/" in _DIR_POOL for name in _NAME_POOL), "no name shared with a directory"
 
     # Finally parse one, so a layout dbt rejects cannot make the generative test vacuous unnoticed.
     biggest = max((_random_layout(random.Random(seed)) for seed in range(8)), key=len)
@@ -1503,26 +1503,26 @@ def test_fqn_prefix_collision_between_sibling_tests_is_parent_scoped(tmp_path):
     """
     _write_project(
         tmp_path,
-        {'check.sql': MODEL_SQL, 'other.sql': MODEL_SQL},
+        {"check.sql": MODEL_SQL, "other.sql": MODEL_SQL},
         schema_yml=(
-            'models:\n'
-            '  - name: check\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '        data_tests:\n'
-            '          - not_null: {name: check}\n'
-            '  - name: other\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '        data_tests:\n'
-            '          - not_null: {name: check.nested}\n'
+            "models:\n"
+            "  - name: check\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        data_tests:\n"
+            "          - not_null: {name: check}\n"
+            "  - name: other\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        data_tests:\n"
+            "          - not_null: {name: check.nested}\n"
         ),
     )
     manifest = _parse(tmp_path)
 
     # dbt's own verdict on the selector an earlier revision emitted.
-    both = _selected_ids(tmp_path, 'probe.check,package:probe,file:schema.yml,test_name:not_null', 'test')
-    assert len(both) == 2, f'expected the prefix collision to select two tests, got {both}'
+    both = _selected_ids(tmp_path, "probe.check,package:probe,file:schema.yml,test_name:not_null", "test")
+    assert len(both) == 2, f"expected the prefix collision to select two tests, got {both}"
 
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
@@ -1536,48 +1536,48 @@ def test_parent_scope_is_refused_when_a_test_term_also_selects_the_parent(tmp_pa
     """
     _write_project(
         tmp_path,
-        {'orders.sql': MODEL_SQL, 'other.sql': MODEL_SQL},
+        {"orders.sql": MODEL_SQL, "other.sql": MODEL_SQL},
         schema_yml=(
-            'models:\n'
-            '  - name: orders\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '        data_tests:\n'
-            '          - not_null: {name: orders}\n'
-            '          - not_null\n'
-            '  - name: other\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '        data_tests:\n'
-            '          - not_null: {name: orders}\n'
+            "models:\n"
+            "  - name: orders\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        data_tests:\n"
+            "          - not_null: {name: orders}\n"
+            "          - not_null\n"
+            "  - name: other\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        data_tests:\n"
+            "          - not_null: {name: orders}\n"
         ),
     )
     manifest = _parse(tmp_path)
 
-    custom_selector = 'fqn:probe.orders,package:probe,file:schema.yml,resource_type:test,test_name:not_null'
-    custom_tests = _selected_unique_ids(tmp_path, custom_selector, None, indirect_selection='empty')
-    assert len(custom_tests) == 2, f'fixture no longer produces the equal direct selectors: {custom_tests}'
+    custom_selector = "fqn:probe.orders,package:probe,file:schema.yml,resource_type:test,test_name:not_null"
+    custom_tests = _selected_unique_ids(tmp_path, custom_selector, None, indirect_selection="empty")
+    assert len(custom_tests) == 2, f"fixture no longer produces the equal direct selectors: {custom_tests}"
 
     intended = next(
         unique_id
         for unique_id in custom_tests
-        if 'model.probe.orders' in manifest['nodes'][unique_id]['depends_on']['nodes']
+        if "model.probe.orders" in manifest["nodes"][unique_id]["depends_on"]["nodes"]
     )
     ordinary_sibling = next(
         unique_id
-        for unique_id, info in manifest['nodes'].items()
-        if info['resource_type'] == 'test'
+        for unique_id, info in manifest["nodes"].items()
+        if info["resource_type"] == "test"
         and unique_id not in custom_tests
-        and 'model.probe.orders' in info['depends_on']['nodes']
+        and "model.probe.orders" in info["depends_on"]["nodes"]
     )
-    would_be_scoped = 'fqn:probe.orders,package:probe,file:orders.sql,resource_type:model,' f'{custom_selector}'
-    cautious_matches = _selected_unique_ids(tmp_path, would_be_scoped, None, indirect_selection='cautious')
+    would_be_scoped = f"fqn:probe.orders,package:probe,file:orders.sql,resource_type:model,{custom_selector}"
+    cautious_matches = _selected_unique_ids(tmp_path, would_be_scoped, None, indirect_selection="cautious")
     assert intended in cautious_matches
-    assert (
-        ordinary_sibling in cautious_matches
-    ), f'fixture no longer demonstrates cautious sibling expansion: {cautious_matches}'
+    assert ordinary_sibling in cautious_matches, (
+        f"fixture no longer demonstrates cautious sibling expansion: {cautious_matches}"
+    )
 
-    with pytest.raises(ValueError, match='also runs'):
+    with pytest.raises(ValueError, match="also runs"):
         _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
 
@@ -1587,42 +1587,42 @@ def test_parent_scope_is_refused_when_a_file_term_selects_the_parent(tmp_path):
     snapshot parent appears to isolate it, but the shared `file:check.sql` term directly selects that
     parent and cautiously expands the snapshot's `check.child` sibling into the finished intersection.
     """
-    _write_project(tmp_path, {'orders.sql': MODEL_SQL})
-    snapshots_dir = tmp_path / 'snapshots' / 'unrelated'
+    _write_project(tmp_path, {"orders.sql": MODEL_SQL})
+    snapshots_dir = tmp_path / "snapshots" / "unrelated"
     snapshots_dir.mkdir(parents=True)
-    (snapshots_dir / 'check.sql').write_text(
+    (snapshots_dir / "check.sql").write_text(
         """{% snapshot other %}
 {{ config(target_schema='snapshots', strategy='check', unique_key='id', check_cols=['id']) }}
 select 1 as id
 {% endsnapshot %}
 """,
-        encoding='utf-8',
+        encoding="utf-8",
     )
-    tests_dir = tmp_path / 'tests'
+    tests_dir = tmp_path / "tests"
     tests_dir.mkdir(parents=True)
-    (tests_dir / 'check.sql').write_text("select * from {{ ref('other') }} where id is null\n", encoding='utf-8')
-    (tests_dir / 'check.child.sql').write_text("select * from {{ ref('other') }} where id is null\n", encoding='utf-8')
-    (tests_dir / 'check.sql.sql').write_text("select * from {{ ref('orders') }} where id is null\n", encoding='utf-8')
+    (tests_dir / "check.sql").write_text("select * from {{ ref('other') }} where id is null\n", encoding="utf-8")
+    (tests_dir / "check.child.sql").write_text("select * from {{ ref('other') }} where id is null\n", encoding="utf-8")
+    (tests_dir / "check.sql.sql").write_text("select * from {{ ref('orders') }} where id is null\n", encoding="utf-8")
     manifest = _parse(tmp_path)
 
     ids_by_path = {
-        info['original_file_path']: unique_id
-        for unique_id, info in manifest['nodes'].items()
-        if info['resource_type'] == 'test'
+        info["original_file_path"]: unique_id
+        for unique_id, info in manifest["nodes"].items()
+        if info["resource_type"] == "test"
     }
-    intended = ids_by_path['tests/check.sql']
-    sibling = ids_by_path['tests/check.child.sql']
-    direct = 'fqn:probe.check,package:probe,file:check.sql,resource_type:test'
-    direct_matches = _selected_unique_ids(tmp_path, direct, None, indirect_selection='empty')
+    intended = ids_by_path["tests/check.sql"]
+    sibling = ids_by_path["tests/check.child.sql"]
+    direct = "fqn:probe.check,package:probe,file:check.sql,resource_type:test"
+    direct_matches = _selected_unique_ids(tmp_path, direct, None, indirect_selection="empty")
     assert intended in direct_matches
-    assert ids_by_path['tests/check.sql.sql'] in direct_matches
+    assert ids_by_path["tests/check.sql.sql"] in direct_matches
 
-    would_be_scoped = 'fqn:probe.unrelated.check.other,package:probe,file:check.sql,resource_type:snapshot,' f'{direct}'
-    cautious_matches = _selected_unique_ids(tmp_path, would_be_scoped, None, indirect_selection='cautious')
+    would_be_scoped = f"fqn:probe.unrelated.check.other,package:probe,file:check.sql,resource_type:snapshot,{direct}"
+    cautious_matches = _selected_unique_ids(tmp_path, would_be_scoped, None, indirect_selection="cautious")
     assert intended in cautious_matches
-    assert sibling in cautious_matches, f'fixture no longer demonstrates cautious sibling expansion: {cautious_matches}'
+    assert sibling in cautious_matches, f"fixture no longer demonstrates cautious sibling expansion: {cautious_matches}"
 
-    with pytest.raises(ValueError, match='also runs'):
+    with pytest.raises(ValueError, match="also runs"):
         _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
 
@@ -1639,36 +1639,36 @@ def test_unit_test_and_data_test_flattening_alike_are_separated_by_resource_type
     _write_project(
         tmp_path,
         {
-            'upstream.sql': MODEL_SQL,
-            'orders.sql': "select * from {{ ref('upstream') }}\n",
-            'customers.sql': MODEL_SQL,
+            "upstream.sql": MODEL_SQL,
+            "orders.sql": "select * from {{ ref('upstream') }}\n",
+            "customers.sql": MODEL_SQL,
         },
         schema_yml=(
-            'models:\n'
-            '  - name: orders\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '  - name: customers\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '        data_tests:\n'
-            '          - not_null: {name: orders.unit_orders}\n'
-            'unit_tests:\n'
-            '  - name: unit_orders\n'
-            '    model: orders\n'
-            '    given:\n'
+            "models:\n"
+            "  - name: orders\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "  - name: customers\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        data_tests:\n"
+            "          - not_null: {name: orders.unit_orders}\n"
+            "unit_tests:\n"
+            "  - name: unit_orders\n"
+            "    model: orders\n"
+            "    given:\n"
             "      - input: ref('upstream')\n"
-            '        rows: [{id: 1}]\n'
-            '    expect: {rows: [{id: 1}]}\n'
+            "        rows: [{id: 1}]\n"
+            "    expect: {rows: [{id: 1}]}\n"
         ),
     )
     manifest = _parse(tmp_path)
-    unit_test = next(iter(manifest['unit_tests'].values()))
-    assert unit_test['depends_on']['nodes'] == ['model.probe.orders']
+    unit_test = next(iter(manifest["unit_tests"].values()))
+    assert unit_test["depends_on"]["nodes"] == ["model.probe.orders"]
 
     # Without the resource-type term the two are indistinguishable.
-    both = _selected_ids(tmp_path, 'probe.orders.unit_orders,package:probe,file:schema.yml', None)
-    assert len(both) == 2, f'expected the flattened fqns to collide, got {both}'
+    both = _selected_ids(tmp_path, "probe.orders.unit_orders,package:probe,file:schema.yml", None)
+    assert len(both) == 2, f"expected the flattened fqns to collide, got {both}"
 
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
@@ -1684,28 +1684,28 @@ def test_versioned_unit_test_clones_have_parent_scoped_tasks(tmp_path):
     """
     _write_project(
         tmp_path,
-        {'orders_v1.sql': MODEL_SQL, 'orders_v2.sql': MODEL_SQL},
+        {"orders_v1.sql": MODEL_SQL, "orders_v2.sql": MODEL_SQL},
         package_model_paths={
-            'probe/orders_v1.sql': MODEL_SQL,
-            'probe/orders_v2.sql': MODEL_SQL,
+            "probe/orders_v1.sql": MODEL_SQL,
+            "probe/orders_v2.sql": MODEL_SQL,
         },
         schema_yml=(
-            'models:\n'
-            '  - name: orders\n'
-            '    latest_version: 2\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '    versions:\n'
-            '      - v: 1\n'
-            '      - v: 2\n'
-            'unit_tests:\n'
-            '  - name: ut_orders\n'
-            '    model: orders\n'
-            '    given: []\n'
-            '    expect: {rows: [{id: 1}]}\n'
+            "models:\n"
+            "  - name: orders\n"
+            "    latest_version: 2\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "    versions:\n"
+            "      - v: 1\n"
+            "      - v: 2\n"
+            "unit_tests:\n"
+            "  - name: ut_orders\n"
+            "    model: orders\n"
+            "    given: []\n"
+            "    expect: {rows: [{id: 1}]}\n"
         ),
     )
-    (tmp_path / 'libs' / 'other' / 'models' / 'probe' / 'schema.yml').write_text(
+    (tmp_path / "libs" / "other" / "models" / "probe" / "schema.yml").write_text(
         """\
 models:
   - name: orders
@@ -1714,28 +1714,28 @@ models:
       - v: 1
       - v: 2
 """,
-        encoding='utf-8',
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
 
     # Guard the fixture: if dbt stops cloning with an identical fqn, this test proves nothing.
-    clones = [info for info in manifest['unit_tests'].values() if info['name'] == 'ut_orders']
-    assert len(clones) == 2, f'expected dbt to clone the unit test per version, got {len(clones)}'
-    assert clones[0]['fqn'] == clones[1]['fqn'], 'dbt now varies the fqn per version; revisit parent scoping'
-    parent_collision = 'fqn:probe.orders.v1,file:orders_v1.sql,resource_type:model'
-    assert (
-        len(_selected_unique_ids(tmp_path, parent_collision, 'model', indirect_selection='empty')) == 2
-    ), 'fixture no longer makes the installed package collide through its package-stripped fqn'
+    clones = [info for info in manifest["unit_tests"].values() if info["name"] == "ut_orders"]
+    assert len(clones) == 2, f"expected dbt to clone the unit test per version, got {len(clones)}"
+    assert clones[0]["fqn"] == clones[1]["fqn"], "dbt now varies the fqn per version; revisit parent scoping"
+    parent_collision = "fqn:probe.orders.v1,file:orders_v1.sql,resource_type:model"
+    assert len(_selected_unique_ids(tmp_path, parent_collision, "model", indirect_selection="empty")) == 2, (
+        "fixture no longer makes the installed package collide through its package-stripped fqn"
+    )
 
     tasks = create_dbt_factory(bundle_tests=False).create_tasks(manifest)
-    unit_tasks = [task for task in tasks if 'unit_test' in task['task_key']]
-    assert len(unit_tasks) == 2, f'expected one task per clone, got {[t["task_key"] for t in unit_tasks]}'
+    unit_tasks = [task for task in tasks if "unit_test" in task["task_key"]]
+    assert len(unit_tasks) == 2, f"expected one task per clone, got {[t['task_key'] for t in unit_tasks]}"
     unique_id_by_task_key = _task_key_to_unique_id(manifest, bundle_tests=False)
     task_key_by_unique_id = {unique_id: task_key for task_key, unique_id in unique_id_by_task_key.items()}
     for task in unit_tasks:
-        clone = manifest['unit_tests'][unique_id_by_task_key[task['task_key']]]
-        parent_unique_id = clone['depends_on']['nodes'][0]
-        assert task['depends_on'] == [{'task_key': task_key_by_unique_id[parent_unique_id]}]
+        clone = manifest["unit_tests"][unique_id_by_task_key[task["task_key"]]]
+        parent_unique_id = clone["depends_on"]["nodes"][0]
+        assert task["depends_on"] == [{"task_key": task_key_by_unique_id[parent_unique_id]}]
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
 
@@ -1750,56 +1750,56 @@ def test_duplicate_test_names_sharing_an_fqn_are_parent_scoped(tmp_path):
     """
     _write_project(
         tmp_path,
-        {'a.sql': MODEL_SQL, 'b.sql': MODEL_SQL},
+        {"a.sql": MODEL_SQL, "b.sql": MODEL_SQL},
         schema_yml=(
-            'models:\n'
-            '  - name: a\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '        data_tests:\n'
-            '          - not_null: {name: check_id}\n'
-            '  - name: b\n'
-            '    columns:\n'
-            '      - name: id\n'
-            '        data_tests:\n'
-            '          - not_null: {name: check_id}\n'
+            "models:\n"
+            "  - name: a\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        data_tests:\n"
+            "          - not_null: {name: check_id}\n"
+            "  - name: b\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        data_tests:\n"
+            "          - not_null: {name: check_id}\n"
         ),
     )
     manifest = _parse(tmp_path)
 
-    fqns = [info['fqn'] for info in manifest['nodes'].values() if info['resource_type'] == 'test']
-    assert fqns[0] == fqns[1], f'expected dbt to allow duplicate test names with one fqn, got {fqns}'
+    fqns = [info["fqn"] for info in manifest["nodes"].values() if info["resource_type"] == "test"]
+    assert fqns[0] == fqns[1], f"expected dbt to allow duplicate test names with one fqn, got {fqns}"
 
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
 
 @pytest.mark.parametrize(
-    ('layout', 'schema_yml', 'note'),
+    ("layout", "schema_yml", "note"),
     [
         pytest.param(
-            {'a.sql': MODEL_SQL},
+            {"a.sql": MODEL_SQL},
             (
-                'models:\n'
-                '  - name: a\n'
-                '    columns:\n'
-                '      - name: id\n'
-                '        data_tests:\n'
+                "models:\n"
+                "  - name: a\n"
+                "    columns:\n"
+                "      - name: id\n"
+                "        data_tests:\n"
                 '          - not_null: {name: "check/slash"}\n'
             ),
-            'a slash would dispatch a bare value to MethodName.Path',
-            id='path-dispatch',
+            "a slash would dispatch a bare value to MethodName.Path",
+            id="path-dispatch",
         ),
         pytest.param(
-            {'orders.sql.sql': MODEL_SQL, 'plain.sql': MODEL_SQL},
+            {"orders.sql.sql": MODEL_SQL, "plain.sql": MODEL_SQL},
             None,
-            'a .sql suffix would dispatch a bare value to MethodName.File',
-            id='file-dispatch',
+            "a .sql suffix would dispatch a bare value to MethodName.File",
+            id="file-dispatch",
         ),
         pytest.param(
-            {'orders.SQL.sql': MODEL_SQL, 'plain.sql': MODEL_SQL},
+            {"orders.SQL.sql": MODEL_SQL, "plain.sql": MODEL_SQL},
             None,
-            'dbt lowercases before testing the suffix, so .SQL dispatches too',
-            id='file-dispatch-uppercase',
+            "dbt lowercases before testing the suffix, so .SQL dispatches too",
+            id="file-dispatch-uppercase",
         ),
     ],
 )
@@ -1830,46 +1830,46 @@ def test_dynamic_reference_in_a_path_is_dropped_from_the_selector(tmp_path):
     catch it. The fqn term is dropped and the bare name carries the node, so the project still works and
     the emitted selector contains no braces for Databricks to substitute.
     """
-    _write_project(tmp_path, {'{{job.id}}/orders.sql': MODEL_SQL, 'plain.sql': MODEL_SQL})
+    _write_project(tmp_path, {"{{job.id}}/orders.sql": MODEL_SQL, "plain.sql": MODEL_SQL})
     manifest = _parse(tmp_path)
 
     # Guard the premise: dbt really does carry the braces into the fqn.
-    assert any('{{job.id}}' in info['fqn'] for info in manifest['nodes'].values())
+    assert any("{{job.id}}" in info["fqn"] for info in manifest["nodes"].values())
 
     for task_key, select, _verb in _resource_selectors(manifest, bundle_tests=False):
-        assert '{{' not in select, f'{task_key} emits {select!r}, which Databricks would substitute'
+        assert "{{" not in select, f"{task_key} emits {select!r}, which Databricks would substitute"
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
 
 def test_literal_braces_are_preserved_and_select_the_real_dbt_node(tmp_path):
-    _write_project(tmp_path, {'orders{draft}.sql': MODEL_SQL, 'plain.sql': MODEL_SQL})
+    _write_project(tmp_path, {"orders{draft}.sql": MODEL_SQL, "plain.sql": MODEL_SQL})
     manifest = _parse(tmp_path)
 
-    brace_node = next(info for info in manifest['nodes'].values() if info['name'] == 'orders{draft}')
-    assert brace_node['fqn'][-1] == 'orders{draft}'
+    brace_node = next(info for info in manifest["nodes"].values() if info["name"] == "orders{draft}")
+    assert brace_node["fqn"][-1] == "orders{draft}"
 
     selectors = _resource_selectors(manifest, bundle_tests=False)
     brace_select = next(
-        select for _task_key, select, _verb in selectors if any('{draft}' in selector for selector in select)
+        select for _task_key, select, _verb in selectors if any("{draft}" in selector for selector in select)
     )
-    assert any('{draft}' in selector for selector in brace_select)
+    assert any("{draft}" in selector for selector in brace_select)
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
 
 def test_selector_terms_cannot_compose_a_dynamic_reference(tmp_path):
-    _write_project(tmp_path, {'orders.sql': MODEL_SQL})
-    (tmp_path / 'models' / 'schema}}.yml').write_text(
-        'models:\n  - name: orders\n    columns:\n      - name: id\n        data_tests:\n'
+    _write_project(tmp_path, {"orders.sql": MODEL_SQL})
+    (tmp_path / "models" / "schema}}.yml").write_text(
+        "models:\n  - name: orders\n    columns:\n      - name: id\n        data_tests:\n"
         '          - not_null: {name: "check{{"}\n',
-        encoding='utf-8',
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
 
     selectors = _resource_selectors(manifest, bundle_tests=False)
-    test_select = next(select for _task_key, select, verb in selectors if verb == 'test')
+    test_select = next(select for _task_key, select, verb in selectors if verb == "test")
     for selector in test_select:
-        assert 'file:schema}}.yml' not in selector
-        assert re.search(r'\{\{[^{}]+\}\}', selector) is None
+        assert "file:schema}}.yml" not in selector
+        assert re.search(r"\{\{[^{}]+\}\}", selector) is None
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
 
@@ -1883,7 +1883,7 @@ def _assert_acyclic(manifest, bundle_tests):
     `test_a_v_named_model_does_not_pick_up_an_unrelated_models_test`.
     """
     tasks = create_dbt_factory(bundle_tests=bundle_tests).create_tasks(manifest)
-    graph = {t['task_key']: {d['task_key'] for d in (t.get('depends_on') or [])} for t in tasks}
+    graph = {t["task_key"]: {d["task_key"] for d in (t.get("depends_on") or [])} for t in tasks}
 
     def reachable(start):
         seen, stack = set(), [start]
@@ -1895,7 +1895,7 @@ def _assert_acyclic(manifest, bundle_tests):
         return seen
 
     cycles = [key for key in graph if key in reachable(key)]
-    assert not cycles, f'bundle_tests={bundle_tests} emitted a cyclic depends_on for {cycles}: {graph}'
+    assert not cycles, f"bundle_tests={bundle_tests} emitted a cyclic depends_on for {cycles}: {graph}"
     return graph
 
 
@@ -1906,17 +1906,17 @@ def test_parent_scoped_versioned_unit_tests_do_not_create_a_dependency_cycle(tmp
     """
     _write_project(
         tmp_path,
-        {'orders_v1.sql': MODEL_SQL, 'orders_v2.sql': "select * from {{ ref('orders', v=1) }}\n"},
+        {"orders_v1.sql": MODEL_SQL, "orders_v2.sql": "select * from {{ ref('orders', v=1) }}\n"},
         schema_yml=(
-            'models:\n  - name: orders\n    latest_version: 2\n'
-            '    columns:\n      - name: id\n'
-            '    versions:\n      - v: 1\n      - v: 2\n'
-            'unit_tests:\n  - name: unit_orders\n    model: orders\n'
-            '    given: []\n    expect: {rows: [{id: 1}]}\n'
+            "models:\n  - name: orders\n    latest_version: 2\n"
+            "    columns:\n      - name: id\n"
+            "    versions:\n      - v: 1\n      - v: 2\n"
+            "unit_tests:\n  - name: unit_orders\n    model: orders\n"
+            "    given: []\n    expect: {rows: [{id: 1}]}\n"
         ),
     )
     manifest = _parse(tmp_path)
-    assert len(manifest['unit_tests']) == 2, 'fixture no longer produces two clones'
+    assert len(manifest["unit_tests"]) == 2, "fixture no longer produces two clones"
 
     # Both modes: `--indirect-selection` changes what a selector resolves to, so bundling reaches a
     # different set of gate edges and has to be asserted separately rather than assumed to follow.
@@ -1932,30 +1932,30 @@ def test_a_downstream_model_is_gated_on_the_exact_versioned_unit_test(tmp_path):
     _write_project(
         tmp_path,
         {
-            'orders_v1.sql': MODEL_SQL,
-            'orders_v2.sql': MODEL_SQL,
-            'consumer.sql': "select * from {{ ref('orders', v=1) }}\n",
+            "orders_v1.sql": MODEL_SQL,
+            "orders_v2.sql": MODEL_SQL,
+            "consumer.sql": "select * from {{ ref('orders', v=1) }}\n",
         },
         schema_yml=(
-            'models:\n  - name: orders\n    latest_version: 2\n'
-            '    columns:\n      - name: id\n'
-            '    versions:\n      - v: 1\n      - v: 2\n'
-            '  - name: consumer\n    columns:\n      - name: id\n'
-            'unit_tests:\n  - name: unit_orders\n    model: orders\n'
-            '    given: []\n    expect: {rows: [{id: 1}]}\n'
+            "models:\n  - name: orders\n    latest_version: 2\n"
+            "    columns:\n      - name: id\n"
+            "    versions:\n      - v: 1\n      - v: 2\n"
+            "  - name: consumer\n    columns:\n      - name: id\n"
+            "unit_tests:\n  - name: unit_orders\n    model: orders\n"
+            "    given: []\n    expect: {rows: [{id: 1}]}\n"
         ),
     )
     manifest = _parse(tmp_path)
 
     tasks = create_dbt_factory(bundle_tests=False).create_tasks(manifest)
-    by_key = {t['task_key']: {d['task_key'] for d in (t.get('depends_on') or [])} for t in tasks}
-    unit_keys = [key for key in by_key if key.startswith('unit_test')]
-    assert unit_keys, f'expected a unit-test task, got {sorted(by_key)}'
+    by_key = {t["task_key"]: {d["task_key"] for d in (t.get("depends_on") or [])} for t in tasks}
+    unit_keys = [key for key in by_key if key.startswith("unit_test")]
+    assert unit_keys, f"expected a unit-test task, got {sorted(by_key)}"
 
-    v1_test = next(key for key in unit_keys if 'orders_v1_model' in by_key[key])
-    v2_test = next(key for key in unit_keys if 'orders_v2_model' in by_key[key])
-    assert v1_test in by_key['consumer_model']
-    assert v2_test not in by_key['consumer_model']
+    v1_test = next(key for key in unit_keys if "orders_v1_model" in by_key[key])
+    v2_test = next(key for key in unit_keys if "orders_v2_model" in by_key[key])
+    assert v1_test in by_key["consumer_model"]
+    assert v2_test not in by_key["consumer_model"]
 
 
 def test_backslash_in_a_posix_file_name_remains_exact_without_a_file_term(tmp_path):
@@ -1963,16 +1963,16 @@ def test_backslash_in_a_posix_file_name_remains_exact_without_a_file_term(tmp_pa
     POSIX treats the backslash as a literal file-name character while Windows treats it as a separator.
     The invariant selector omits `file:` and the remaining terms still resolve exactly.
     """
-    _write_project(tmp_path, {'we\\ird.sql': MODEL_SQL, 'plain.sql': MODEL_SQL})
+    _write_project(tmp_path, {"we\\ird.sql": MODEL_SQL, "plain.sql": MODEL_SQL})
     manifest = _parse(tmp_path)
     task_to_id = _task_key_to_unique_id(manifest, bundle_tests=False)
     selectors = next(
         selectors
         for task_key, selectors, verb in _resource_selectors(manifest, bundle_tests=False)
-        if verb == 'run' and task_to_id[task_key] == 'model.probe.we\\ird'
+        if verb == "run" and task_to_id[task_key] == "model.probe.we\\ird"
     )
 
-    assert all(not term.startswith('file:') for term in selectors[0].split(','))
+    assert all(not term.startswith("file:") for term in selectors[0].split(","))
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
 
@@ -1981,24 +1981,24 @@ def test_file_stem_collision_uses_an_exact_parent_scope(tmp_path):
     `file:a.yml` reaches nodes declared in both `a.yml` and `a.yml.yml`. The shorter test fqn also
     prefixes the nested test, so its direct selector is ambiguous and requires an exact-parent scope.
     """
-    _write_project(tmp_path, {'q.sql': MODEL_SQL, 'r.sql': MODEL_SQL})
-    (tmp_path / 'models' / 'a.yml').write_text(
-        'models:\n  - name: q\n    columns:\n      - name: id\n        data_tests:\n'
-        '          - not_null: {name: chk}\n',
-        encoding='utf-8',
+    _write_project(tmp_path, {"q.sql": MODEL_SQL, "r.sql": MODEL_SQL})
+    (tmp_path / "models" / "a.yml").write_text(
+        "models:\n  - name: q\n    columns:\n      - name: id\n        data_tests:\n"
+        "          - not_null: {name: chk}\n",
+        encoding="utf-8",
     )
-    (tmp_path / 'models' / 'a.yml.yml').write_text(
-        'models:\n  - name: r\n    columns:\n      - name: id\n        data_tests:\n'
-        '          - not_null: {name: chk.nested}\n',
-        encoding='utf-8',
+    (tmp_path / "models" / "a.yml.yml").write_text(
+        "models:\n  - name: r\n    columns:\n      - name: id\n        data_tests:\n"
+        "          - not_null: {name: chk.nested}\n",
+        encoding="utf-8",
     )
     manifest = _parse(tmp_path)
 
     bare = _selected_unique_ids(
-        tmp_path, 'probe.chk,package:probe,file:a.yml,resource_type:test,test_name:not_null', None
+        tmp_path, "probe.chk,package:probe,file:a.yml,resource_type:test,test_name:not_null", None
     )
     explicit = _selected_unique_ids(
-        tmp_path, 'fqn:probe.chk,package:probe,file:a.yml,resource_type:test,test_name:not_null', None
+        tmp_path, "fqn:probe.chk,package:probe,file:a.yml,resource_type:test,test_name:not_null", None
     )
     assert len(bare) == 2
     assert explicit == bare
@@ -2006,10 +2006,10 @@ def test_file_stem_collision_uses_an_exact_parent_scope(tmp_path):
     tasks = create_dbt_factory(bundle_tests=False).create_tasks(manifest)
     test_commands = []
     for task in tasks:
-        if task['dbt_task']['commands'][-1].startswith('dbt test'):
-            test_commands.append(shlex.split(task['dbt_task']['commands'][-1]))
-    modes = [command[command.index('--indirect-selection') + 1] for command in test_commands]
-    assert sorted(modes) == ['cautious', 'empty']
+        if task["dbt_task"]["commands"][-1].startswith("dbt test"):
+            test_commands.append(shlex.split(task["dbt_task"]["commands"][-1]))
+    modes = [command[command.index("--indirect-selection") + 1] for command in test_commands]
+    assert sorted(modes) == ["cautious", "empty"]
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
 
@@ -2019,25 +2019,25 @@ def test_singular_test_named_after_a_model_without_other_tests_is_kept(tmp_path)
     `--indirect-selection empty` prevents attached-test expansion. The selector resolves to exactly the
     singular test, confirmed with `dbt ls` on dbt 1.12.0.
     """
-    _write_project(tmp_path, {'orders.sql': MODEL_SQL})
-    tests_dir = tmp_path / 'tests'
+    _write_project(tmp_path, {"orders.sql": MODEL_SQL})
+    tests_dir = tmp_path / "tests"
     tests_dir.mkdir(parents=True, exist_ok=True)
-    (tests_dir / 'orders.sql').write_text("select * from {{ ref('orders') }} where id is null\n", encoding='utf-8')
+    (tests_dir / "orders.sql").write_text("select * from {{ ref('orders') }} where id is null\n", encoding="utf-8")
     manifest = _parse(tmp_path)
 
     # dbt reports both by the same name `probe.orders`, so assert per task with the resource type its
     # command carries — the shared name is exactly why `_assert_each_task_selects_its_own_node` cannot
     # distinguish them here.
-    assert _selected_ids(tmp_path, 'probe.orders,package:probe,file:orders.sql,resource_type:test', None) == (
-        'probe.orders',
+    assert _selected_ids(tmp_path, "probe.orders,package:probe,file:orders.sql,resource_type:test", None) == (
+        "probe.orders",
     )
     selectors = {verb: select for _key, select, verb in _resource_selectors(manifest, bundle_tests=False)}
-    assert set(selectors) == {'run', 'test'}, f'expected a model task and a test task, got {selectors}'
+    assert set(selectors) == {"run", "test"}, f"expected a model task and a test task, got {selectors}"
     for verb, select in selectors.items():
-        resource_type = 'model' if verb == 'run' else 'test'
-        assert _selected_ids(tmp_path, select, resource_type) == (
-            'probe.orders',
-        ), f'the {verb} task must resolve to exactly its own node via {select!r}'
+        resource_type = "model" if verb == "run" else "test"
+        assert _selected_ids(tmp_path, select, resource_type) == ("probe.orders",), (
+            f"the {verb} task must resolve to exactly its own node via {select!r}"
+        )
 
 
 def _assert_prediction_matches_dbt(tmp_path, manifest, bundle_tests):
@@ -2054,38 +2054,37 @@ def _assert_prediction_matches_dbt(tmp_path, manifest, bundle_tests):
     expansion.
     """
     peers = {
-        **{k: v for k, v in manifest['nodes'].items() if (v.get('config') or {}).get('enabled') is not False},
-        **manifest.get('unit_tests', {}),
-        **manifest.get('sources', {}),
+        **{k: v for k, v in manifest["nodes"].items() if (v.get("config") or {}).get("enabled") is not False},
+        **manifest.get("unit_tests", {}),
+        **manifest.get("sources", {}),
     }
     index = DbtFactory._selector_index(peers)  # pylint: disable=protected-access
     expected_by_key = _task_key_to_unique_id(manifest, bundle_tests)
     bundled_by_key = _bundled_test_ids_by_task_key(manifest) if bundle_tests else {}
     for task in create_dbt_factory(bundle_tests=bundle_tests).create_tasks(manifest):
-        task_key = task['task_key']
+        task_key = task["task_key"]
         if task_key in bundled_by_key:
             actual = _selected_by_bundled_commands(tmp_path, task) & set(peers)
             expected = bundled_by_key[task_key]
             assert actual == expected, (
-                f'{task_key}: dbt runs {sorted(actual)}, expected exact bundle membership ' f'{sorted(expected)}'
+                f"{task_key}: dbt runs {sorted(actual)}, expected exact bundle membership {sorted(expected)}"
             )
             continue
 
-        command = shlex.split(task['dbt_task']['commands'][-1])
+        command = shlex.split(task["dbt_task"]["commands"][-1])
         verb = command[1]
         select = _command_selectors(command)
-        if any(selector.startswith('source:') for selector in select):
+        if any(selector.startswith("source:") for selector in select):
             continue
-        mode = command[command.index('--indirect-selection') + 1] if '--indirect-selection' in command else None
-        resource_type = None if verb == 'test' else {'run': 'model', 'seed': 'seed', 'snapshot': 'snapshot'}[verb]
+        mode = command[command.index("--indirect-selection") + 1] if "--indirect-selection" in command else None
+        resource_type = None if verb == "test" else {"run": "model", "seed": "seed", "snapshot": "snapshot"}[verb]
         # Compare on unique ids: `_selected_ids` returns the *display* names `dbt ls` prints, which do not
         # match manifest keys, so intersecting those with `peers` would silently compare against nothing.
         actual = set(_selected_unique_ids(tmp_path, select, resource_type, indirect_selection=mode)) & set(peers)
-        if mode == 'cautious':
+        if mode == "cautious":
             expected = {expected_by_key[task_key]}
             assert actual == expected, (
-                f'{task_key}: cautious plan runs {sorted(actual)}, expected exactly {sorted(expected)} '
-                f'for {select!r}'
+                f"{task_key}: cautious plan runs {sorted(actual)}, expected exactly {sorted(expected)} for {select!r}"
             )
             continue
         # The model predicts one selector at a time, so a bundled union is predicted term by term and
@@ -2095,68 +2094,68 @@ def _assert_prediction_matches_dbt(tmp_path, manifest, bundle_tests):
             for selector in select
             for unique_id in DbtFactory._matching_ids(selector, index)  # pylint: disable=protected-access
         }
-        assert (
-            predicted == actual
-        ), f'{task_key}: model predicts {sorted(predicted)} but dbt runs {sorted(actual)} for {select!r}'
+        assert predicted == actual, (
+            f"{task_key}: model predicts {sorted(predicted)} but dbt runs {sorted(actual)} for {select!r}"
+        )
 
 
-@pytest.mark.parametrize('bundle_tests', [False, True], ids=['per-test', 'bundled'])
+@pytest.mark.parametrize("bundle_tests", [False, True], ids=["per-test", "bundled"])
 @pytest.mark.parametrize(
-    ('layout', 'schema_yml', 'extra'),
+    ("layout", "schema_yml", "extra"),
     [
-        pytest.param({'a.sql': MODEL_SQL, 'b.sql': MODEL_SQL}, None, None, id='plain'),
-        pytest.param({'marts/orders.sql': MODEL_SQL, 'marts/orders/items.sql': MODEL_SQL}, None, None, id='nested'),
+        pytest.param({"a.sql": MODEL_SQL, "b.sql": MODEL_SQL}, None, None, id="plain"),
+        pytest.param({"marts/orders.sql": MODEL_SQL, "marts/orders/items.sql": MODEL_SQL}, None, None, id="nested"),
         pytest.param(
-            {'a.sql': MODEL_SQL, 'b.sql': MODEL_SQL},
-            'models:\n  - name: a\n    columns:\n      - name: id\n        data_tests: [not_null, unique]\n'
-            '  - name: b\n    columns:\n      - name: id\n        data_tests: [not_null]\n',
+            {"a.sql": MODEL_SQL, "b.sql": MODEL_SQL},
+            "models:\n  - name: a\n    columns:\n      - name: id\n        data_tests: [not_null, unique]\n"
+            "  - name: b\n    columns:\n      - name: id\n        data_tests: [not_null]\n",
             None,
-            id='attached-tests',
+            id="attached-tests",
         ),
         pytest.param(
-            {'a.sql': MODEL_SQL, 'b.sql': MODEL_SQL},
-            'models:\n  - name: a\n    columns:\n      - name: id\n        data_tests:\n'
-            '          - not_null: {name: check_id}\n'
-            '  - name: b\n    columns:\n      - name: id\n        data_tests:\n'
-            '          - not_null: {name: check_id}\n',
+            {"a.sql": MODEL_SQL, "b.sql": MODEL_SQL},
+            "models:\n  - name: a\n    columns:\n      - name: id\n        data_tests:\n"
+            "          - not_null: {name: check_id}\n"
+            "  - name: b\n    columns:\n      - name: id\n        data_tests:\n"
+            "          - not_null: {name: check_id}\n",
             None,
-            id='parent-scoped-tests',
+            id="parent-scoped-tests",
         ),
         pytest.param(
-            {'beta.sql': MODEL_SQL, 'delta.sql': MODEL_SQL},
-            'models:\n  - name: beta\n    columns:\n      - name: id\n        data_tests:\n'
+            {"beta.sql": MODEL_SQL, "delta.sql": MODEL_SQL},
+            "models:\n  - name: beta\n    columns:\n      - name: id\n        data_tests:\n"
             '          - relationships: {to: ref("delta"), field: id}\n'
-            '  - name: delta\n    columns:\n      - name: id\n',
+            "  - name: delta\n    columns:\n      - name: id\n",
             None,
-            id='relationships',
+            id="relationships",
         ),
         pytest.param(
-            {'beta.sql': MODEL_SQL},
+            {"beta.sql": MODEL_SQL},
             None,
-            {'tests/beta_is_sane.sql': "select * from {{ ref('beta') }} where id is null\n"},
-            id='singular-test',
+            {"tests/beta_is_sane.sql": "select * from {{ ref('beta') }} where id is null\n"},
+            id="singular-test",
         ),
         pytest.param(
-            {'orders.sql': MODEL_SQL},
-            'models:\n  - name: orders\n    columns:\n      - name: id\n        data_tests: [not_null]\n'
-            'unit_tests:\n  - name: ut\n    model: orders\n    given: []\n    expect: {rows: [{id: 1}]}\n',
+            {"orders.sql": MODEL_SQL},
+            "models:\n  - name: orders\n    columns:\n      - name: id\n        data_tests: [not_null]\n"
+            "unit_tests:\n  - name: ut\n    model: orders\n    given: []\n    expect: {rows: [{id: 1}]}\n",
             None,
-            id='unit-and-data-test',
+            id="unit-and-data-test",
         ),
         pytest.param(
-            {'orders_v1.sql': MODEL_SQL, 'orders_v2.sql': MODEL_SQL},
-            'models:\n  - name: orders\n    latest_version: 2\n    columns:\n      - name: id\n'
-            '    versions:\n      - v: 1\n      - v: 2\n',
+            {"orders_v1.sql": MODEL_SQL, "orders_v2.sql": MODEL_SQL},
+            "models:\n  - name: orders\n    latest_version: 2\n    columns:\n      - name: id\n"
+            "    versions:\n      - v: 1\n      - v: 2\n",
             None,
-            id='versioned',
+            id="versioned",
         ),
         pytest.param(
-            {'a.sql': MODEL_SQL, 'b.sql': "select * from {{ ref('a') }}\n", 'c.sql': "select * from {{ ref('b') }}\n"},
-            'models:\n  - name: a\n    columns:\n      - name: id\n        data_tests: [not_null]\n'
-            '  - name: b\n    columns:\n      - name: id\n        data_tests: [not_null]\n'
-            '  - name: c\n    columns:\n      - name: id\n        data_tests: [not_null]\n',
+            {"a.sql": MODEL_SQL, "b.sql": "select * from {{ ref('a') }}\n", "c.sql": "select * from {{ ref('b') }}\n"},
+            "models:\n  - name: a\n    columns:\n      - name: id\n        data_tests: [not_null]\n"
+            "  - name: b\n    columns:\n      - name: id\n        data_tests: [not_null]\n"
+            "  - name: c\n    columns:\n      - name: id\n        data_tests: [not_null]\n",
             None,
-            id='chained',
+            id="chained",
         ),
     ],
 )
@@ -2171,7 +2170,7 @@ def test_exactness_model_predicts_what_dbt_runs(tmp_path, layout, schema_yml, ex
     for relative_path, content in (extra or {}).items():
         target = tmp_path / relative_path
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(content, encoding='utf-8')
+        target.write_text(content, encoding="utf-8")
     manifest = _parse(tmp_path)
 
     _assert_prediction_matches_dbt(tmp_path, manifest, bundle_tests)
@@ -2190,19 +2189,19 @@ def test_attached_test_leaking_through_a_non_matching_model_is_prevented_by_empt
     """
     _write_project(
         tmp_path,
-        {'orders.sql': MODEL_SQL, 'other.sql': MODEL_SQL},
+        {"orders.sql": MODEL_SQL, "other.sql": MODEL_SQL},
         schema_yml=(
-            'models:\n'
-            '  - name: orders\n    columns:\n      - name: id\n        data_tests: [not_null]\n'
-            '  - name: other\n    columns:\n      - name: id\n        data_tests:\n'
-            '          - not_null: {name: orders}\n'
+            "models:\n"
+            "  - name: orders\n    columns:\n      - name: id\n        data_tests: [not_null]\n"
+            "  - name: other\n    columns:\n      - name: id\n        data_tests:\n"
+            "          - not_null: {name: orders}\n"
         ),
     )
     manifest = _parse(tmp_path)
 
-    leaky = 'fqn:probe.orders,package:probe,file:schema.yml,resource_type:test,test_name:not_null'
-    assert len(_selected_unique_ids(tmp_path, leaky, None)) == 2, 'eager no longer leaks; revisit this test'
-    assert len(_selected_unique_ids(tmp_path, leaky, None, indirect_selection='empty')) == 1
+    leaky = "fqn:probe.orders,package:probe,file:schema.yml,resource_type:test,test_name:not_null"
+    assert len(_selected_unique_ids(tmp_path, leaky, None)) == 2, "eager no longer leaks; revisit this test"
+    assert len(_selected_unique_ids(tmp_path, leaky, None, indirect_selection="empty")) == 1
 
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
@@ -2217,23 +2216,23 @@ def test_multi_endpoint_test_leaking_from_one_endpoint_is_prevented_by_empty(tmp
     """
     _write_project(
         tmp_path,
-        {'beta.sql': MODEL_SQL, 'delta.sql': MODEL_SQL, 'gamma.sql': MODEL_SQL},
+        {"beta.sql": MODEL_SQL, "delta.sql": MODEL_SQL, "gamma.sql": MODEL_SQL},
         schema_yml=(
-            'models:\n'
-            '  - name: beta\n    columns:\n      - name: id\n        data_tests:\n'
+            "models:\n"
+            "  - name: beta\n    columns:\n      - name: id\n        data_tests:\n"
             '          - relationships: {to: ref("delta"), field: id}\n'
-            '  - name: delta\n    columns:\n      - name: id\n'
-            '  - name: gamma\n    columns:\n      - name: id\n'
+            "  - name: delta\n    columns:\n      - name: id\n"
+            "  - name: gamma\n    columns:\n      - name: id\n"
         ),
     )
-    tests_dir = tmp_path / 'tests'
+    tests_dir = tmp_path / "tests"
     tests_dir.mkdir(parents=True, exist_ok=True)
-    (tests_dir / 'beta.sql').write_text("select * from {{ ref('gamma') }} where id is null\n", encoding='utf-8')
+    (tests_dir / "beta.sql").write_text("select * from {{ ref('gamma') }} where id is null\n", encoding="utf-8")
     manifest = _parse(tmp_path)
 
-    leaky = 'fqn:probe.beta,package:probe,file:beta.sql,resource_type:test'
-    assert len(_selected_unique_ids(tmp_path, leaky, None)) == 2, 'eager no longer leaks; revisit this test'
-    assert len(_selected_unique_ids(tmp_path, leaky, None, indirect_selection='empty')) == 1
+    leaky = "fqn:probe.beta,package:probe,file:beta.sql,resource_type:test"
+    assert len(_selected_unique_ids(tmp_path, leaky, None)) == 2, "eager no longer leaks; revisit this test"
+    assert len(_selected_unique_ids(tmp_path, leaky, None, indirect_selection="empty")) == 1
 
     _assert_each_task_selects_its_own_node(tmp_path, manifest, bundle_tests=False)
 
@@ -2248,19 +2247,19 @@ def test_interlocking_cross_model_tests_do_not_create_a_cycle(tmp_path):
     _write_project(
         tmp_path,
         {
-            'a.sql': MODEL_SQL,
-            'c.sql': MODEL_SQL,
-            'n.sql': "select * from {{ ref('a') }}\n",
-            'b.sql': "select * from {{ ref('c') }}\n",
+            "a.sql": MODEL_SQL,
+            "c.sql": MODEL_SQL,
+            "n.sql": "select * from {{ ref('a') }}\n",
+            "b.sql": "select * from {{ ref('c') }}\n",
         },
         schema_yml=(
-            'models:\n'
-            '  - name: a\n    columns:\n      - name: id\n        data_tests:\n'
+            "models:\n"
+            "  - name: a\n    columns:\n      - name: id\n        data_tests:\n"
             '          - relationships: {to: ref("b"), field: id}\n'
-            '  - name: c\n    columns:\n      - name: id\n        data_tests:\n'
+            "  - name: c\n    columns:\n      - name: id\n        data_tests:\n"
             '          - relationships: {to: ref("n"), field: id}\n'
-            '  - name: n\n    columns:\n      - name: id\n'
-            '  - name: b\n    columns:\n      - name: id\n'
+            "  - name: n\n    columns:\n      - name: id\n"
+            "  - name: b\n    columns:\n      - name: id\n"
         ),
     )
     manifest = _parse(tmp_path)
@@ -2279,19 +2278,19 @@ def test_interlocking_tests_on_v_prefixed_models_do_not_create_a_cycle(tmp_path)
     _write_project(
         tmp_path,
         {
-            'va.sql': MODEL_SQL,
-            'vc.sql': MODEL_SQL,
-            'vn.sql': "select * from {{ ref('va') }}\n",
-            'vb.sql': "select * from {{ ref('vc') }}\n",
+            "va.sql": MODEL_SQL,
+            "vc.sql": MODEL_SQL,
+            "vn.sql": "select * from {{ ref('va') }}\n",
+            "vb.sql": "select * from {{ ref('vc') }}\n",
         },
         schema_yml=(
-            'models:\n'
-            '  - name: va\n    columns:\n      - name: id\n        data_tests:\n'
+            "models:\n"
+            "  - name: va\n    columns:\n      - name: id\n        data_tests:\n"
             '          - relationships: {to: ref("vb"), field: id}\n'
-            '  - name: vc\n    columns:\n      - name: id\n        data_tests:\n'
+            "  - name: vc\n    columns:\n      - name: id\n        data_tests:\n"
             '          - relationships: {to: ref("vn"), field: id}\n'
-            '  - name: vn\n    columns:\n      - name: id\n'
-            '  - name: vb\n    columns:\n      - name: id\n'
+            "  - name: vn\n    columns:\n      - name: id\n"
+            "  - name: vb\n    columns:\n      - name: id\n"
         ),
     )
     manifest = _parse(tmp_path)
@@ -2300,25 +2299,25 @@ def test_interlocking_tests_on_v_prefixed_models_do_not_create_a_cycle(tmp_path)
         _assert_acyclic(manifest, bundle_tests)
 
 
-def _cross_referencing_versioned_project(tmp_path, first: str = 'alpha', second: str = 'beta') -> dict:
+def _cross_referencing_versioned_project(tmp_path, first: str = "alpha", second: str = "beta") -> dict:
     """Builds two versioned models whose later versions reference each other's earlier version."""
     _write_project(
         tmp_path,
         {
-            f'{first}_v1.sql': MODEL_SQL,
-            f'{first}_v2.sql': "select * from {{ ref('%s', v=1) }}\n" % second,
-            f'{second}_v1.sql': MODEL_SQL,
-            f'{second}_v2.sql': "select * from {{ ref('%s', v=1) }}\n" % first,
+            f"{first}_v1.sql": MODEL_SQL,
+            f"{first}_v2.sql": "select * from {{ ref('%s', v=1) }}\n" % second,
+            f"{second}_v1.sql": MODEL_SQL,
+            f"{second}_v2.sql": "select * from {{ ref('%s', v=1) }}\n" % first,
         },
         schema_yml=(
-            'models:\n'
-            f'  - name: {first}\n    latest_version: 2\n    columns:\n      - name: id\n'
-            '    versions:\n      - v: 1\n      - v: 2\n'
-            f'  - name: {second}\n    latest_version: 2\n    columns:\n      - name: id\n'
-            '    versions:\n      - v: 1\n      - v: 2\n'
-            'unit_tests:\n'
-            f'  - name: ut_{first}\n    model: {first}\n    given: []\n    expect: {{rows: [{{id: 1}}]}}\n'
-            f'  - name: ut_{second}\n    model: {second}\n    given: []\n    expect: {{rows: [{{id: 1}}]}}\n'
+            "models:\n"
+            f"  - name: {first}\n    latest_version: 2\n    columns:\n      - name: id\n"
+            "    versions:\n      - v: 1\n      - v: 2\n"
+            f"  - name: {second}\n    latest_version: 2\n    columns:\n      - name: id\n"
+            "    versions:\n      - v: 1\n      - v: 2\n"
+            "unit_tests:\n"
+            f"  - name: ut_{first}\n    model: {first}\n    given: []\n    expect: {{rows: [{{id: 1}}]}}\n"
+            f"  - name: ut_{second}\n    model: {second}\n    given: []\n    expect: {{rows: [{{id: 1}}]}}\n"
         ),
     )
     return _parse(tmp_path)
@@ -2335,12 +2334,12 @@ def test_cross_referencing_versioned_models_use_exact_clone_gates(tmp_path):
 
     graph = _assert_acyclic(manifest, bundle_tests=False)
     unit_by_parent = {
-        next(dep for dep in dependencies if dep.endswith('_model')): task_key
+        next(dep for dep in dependencies if dep.endswith("_model")): task_key
         for task_key, dependencies in graph.items()
-        if task_key.startswith('unit_test_')
+        if task_key.startswith("unit_test_")
     }
-    assert unit_by_parent['beta_v1_model'] in graph['alpha_v2_model']
-    assert unit_by_parent['alpha_v1_model'] in graph['beta_v2_model']
+    assert unit_by_parent["beta_v1_model"] in graph["alpha_v2_model"]
+    assert unit_by_parent["alpha_v1_model"] in graph["beta_v2_model"]
     _assert_acyclic(manifest, bundle_tests=True)
 
 
@@ -2352,18 +2351,18 @@ def test_a_cross_model_data_test_uses_the_safe_subset_rule(tmp_path):
     _write_project(
         tmp_path,
         {
-            'alpha_v1.sql': MODEL_SQL,
-            'alpha_v2.sql': "select * from {{ ref('nn') }}\n",
-            'xm.sql': "select * from {{ ref('alpha', v=1) }}\n",
-            'nn.sql': "select * from {{ ref('xm') }}\n",
+            "alpha_v1.sql": MODEL_SQL,
+            "alpha_v2.sql": "select * from {{ ref('nn') }}\n",
+            "xm.sql": "select * from {{ ref('alpha', v=1) }}\n",
+            "nn.sql": "select * from {{ ref('xm') }}\n",
         },
         schema_yml=(
-            'models:\n'
-            '  - name: alpha\n    latest_version: 2\n    columns:\n      - name: id\n'
-            '    versions:\n      - v: 1\n      - v: 2\n'
-            '  - name: xm\n    columns:\n      - name: id\n        data_tests:\n'
-            '          - relationships:\n              to: ref(\'alpha\', v=2)\n              field: id\n'
-            '  - name: nn\n    columns:\n      - name: id\n'
+            "models:\n"
+            "  - name: alpha\n    latest_version: 2\n    columns:\n      - name: id\n"
+            "    versions:\n      - v: 1\n      - v: 2\n"
+            "  - name: xm\n    columns:\n      - name: id\n        data_tests:\n"
+            "          - relationships:\n              to: ref('alpha', v=2)\n              field: id\n"
+            "  - name: nn\n    columns:\n      - name: id\n"
         ),
     )
     manifest = _parse(tmp_path)
@@ -2372,9 +2371,9 @@ def test_a_cross_model_data_test_uses_the_safe_subset_rule(tmp_path):
 
     # And the edge is simply absent, as the subset rule always left it — `nn` is not downstream of
     # `alpha.v2`, so the test cannot gate it either way.
-    assert not any(
-        'relationships' in dep for dep in graph['nn_model']
-    ), f'nn_model deps {sorted(graph["nn_model"])} include a cross-model test it is not downstream of'
+    assert not any("relationships" in dep for dep in graph["nn_model"]), (
+        f"nn_model deps {sorted(graph['nn_model'])} include a cross-model test it is not downstream of"
+    )
 
 
 def _cross_version_data_test_project(tmp_path) -> dict:
@@ -2387,19 +2386,19 @@ def _cross_version_data_test_project(tmp_path) -> dict:
     _write_project(
         tmp_path,
         {
-            'alpha_v1.sql': MODEL_SQL,
-            'alpha_v2.sql': "select * from {{ ref('nn') }}\n",
-            'nn.sql': "select * from {{ ref('alpha', v=1) }}\n",
+            "alpha_v1.sql": MODEL_SQL,
+            "alpha_v2.sql": "select * from {{ ref('nn') }}\n",
+            "nn.sql": "select * from {{ ref('alpha', v=1) }}\n",
         },
         schema_yml=(
-            'models:\n'
-            '  - name: alpha\n    latest_version: 2\n    columns:\n      - name: id\n'
-            '    versions:\n'
-            '      - v: 1\n        columns:\n          - name: id\n            data_tests:\n'
-            '              - relationships:\n                  to: ref(\'alpha\', v=2)\n'
-            '                  field: id\n'
-            '      - v: 2\n'
-            '  - name: nn\n    columns:\n      - name: id\n'
+            "models:\n"
+            "  - name: alpha\n    latest_version: 2\n    columns:\n      - name: id\n"
+            "    versions:\n"
+            "      - v: 1\n        columns:\n          - name: id\n            data_tests:\n"
+            "              - relationships:\n                  to: ref('alpha', v=2)\n"
+            "                  field: id\n"
+            "      - v: 2\n"
+            "  - name: nn\n    columns:\n      - name: id\n"
         ),
     )
     return _parse(tmp_path)
@@ -2412,9 +2411,9 @@ def test_a_cross_version_data_test_uses_the_safe_subset_rule(tmp_path):
     """
     manifest = _cross_version_data_test_project(tmp_path)
 
-    assert not manifest['unit_tests'], 'fixture must contain no unit tests for this to test what it claims'
+    assert not manifest["unit_tests"], "fixture must contain no unit tests for this to test what it claims"
     graph = _assert_acyclic(manifest, bundle_tests=False)
-    assert not any('relationships' in dep for dep in graph['nn_model'])
+    assert not any("relationships" in dep for dep in graph["nn_model"])
     _assert_acyclic(manifest, bundle_tests=True)
 
 
@@ -2426,29 +2425,29 @@ def test_a_v_named_model_does_not_pick_up_an_unrelated_models_test(tmp_path):
     _write_project(
         tmp_path,
         {
-            'vendors.sql': MODEL_SQL,
-            'visits.sql': MODEL_SQL,
-            'downstream.sql': "select * from {{ ref('vendors') }}\n",
+            "vendors.sql": MODEL_SQL,
+            "visits.sql": MODEL_SQL,
+            "downstream.sql": "select * from {{ ref('vendors') }}\n",
         },
         schema_yml=(
-            'models:\n'
-            '  - name: vendors\n    columns:\n      - name: id\n'
-            '  - name: visits\n    columns:\n      - name: id\n        data_tests:\n'
-            '          - relationships:\n              to: ref(\'vendors\')\n              field: id\n'
-            '  - name: downstream\n    columns:\n      - name: id\n'
+            "models:\n"
+            "  - name: vendors\n    columns:\n      - name: id\n"
+            "  - name: visits\n    columns:\n      - name: id\n        data_tests:\n"
+            "          - relationships:\n              to: ref('vendors')\n              field: id\n"
+            "  - name: downstream\n    columns:\n      - name: id\n"
         ),
     )
     manifest = _parse(tmp_path)
 
     # Guard the premise: none of these is a versioned model.
-    assert all(info.get('version') is None for info in manifest['nodes'].values() if info['resource_type'] == 'model')
+    assert all(info.get("version") is None for info in manifest["nodes"].values() if info["resource_type"] == "model")
 
     tasks = create_dbt_factory(bundle_tests=False).create_tasks(manifest)
-    deps = {t['task_key']: {d['task_key'] for d in (t.get('depends_on') or [])} for t in tasks}
+    deps = {t["task_key"]: {d["task_key"] for d in (t.get("depends_on") or [])} for t in tasks}
 
-    assert deps['downstream_model'] == {'vendors_model'}, (
-        f'downstream_model deps {sorted(deps["downstream_model"])} include a test of `visits`, which it '
-        f'does not depend on'
+    assert deps["downstream_model"] == {"vendors_model"}, (
+        f"downstream_model deps {sorted(deps['downstream_model'])} include a test of `visits`, which it "
+        f"does not depend on"
     )
 
 
@@ -2461,7 +2460,7 @@ def _random_gating_project(rng: random.Random) -> tuple[dict[str, str], str]:
     models, the shape the safe-subset rule judges), and versioned models with unit tests. Half the names
     begin with `v` so ordinary identifiers resembling version segments remain covered.
     """
-    names = ['va', 'vb', 'orders', 'items'][: rng.randint(2, 4)]
+    names = ["va", "vb", "orders", "items"][: rng.randint(2, 4)]
     versioned = {name for name in names if rng.random() < 0.4}
 
     files: dict[str, str] = {}
@@ -2481,19 +2480,19 @@ def _random_gating_project(rng: random.Random) -> tuple[dict[str, str], str]:
             return "select * from {{ ref('%s') }}\n" % target
 
         if name in versioned:
-            files[f'{name}_v1.sql'] = ref_to_earlier()
-            files[f'{name}_v2.sql'] = ref_to_earlier()
+            files[f"{name}_v1.sql"] = ref_to_earlier()
+            files[f"{name}_v2.sql"] = ref_to_earlier()
             model_entries.append(
-                f'  - name: {name}\n    latest_version: 2\n    columns:\n      - name: id\n'
-                f'    versions:\n      - v: 1\n      - v: 2\n'
+                f"  - name: {name}\n    latest_version: 2\n    columns:\n      - name: id\n"
+                f"    versions:\n      - v: 1\n      - v: 2\n"
             )
             if rng.random() < 0.7:
                 unit_tests.append(
-                    f'  - name: ut_{name}\n    model: {name}\n    given: []\n    expect: {{rows: [{{id: 1}}]}}\n'
+                    f"  - name: ut_{name}\n    model: {name}\n    given: []\n    expect: {{rows: [{{id: 1}}]}}\n"
                 )
         else:
-            files[f'{name}.sql'] = ref_to_earlier()
-            model_entries.append(f'  - name: {name}\n    columns:\n      - name: id\n')
+            files[f"{name}.sql"] = ref_to_earlier()
+            model_entries.append(f"  - name: {name}\n    columns:\n      - name: id\n")
         emitted.append((name, name in versioned))
 
     # `relationships` tests come last so both endpoints exist. They are what the subset rule is for: a
@@ -2506,15 +2505,15 @@ def _random_gating_project(rng: random.Random) -> tuple[dict[str, str], str]:
         # Block style, not `{to: ..., field: id}`: the comma inside a versioned `ref('x', v=1)` is a
         # separator in YAML flow style, which dbt then rejects as a keyword argument to the test macro.
         model_entries[index] = entry.replace(
-            '      - name: id\n',
-            '      - name: id\n        data_tests:\n'
-            f'          - relationships:\n              to: {target}\n              field: id\n',
+            "      - name: id\n",
+            "      - name: id\n        data_tests:\n"
+            f"          - relationships:\n              to: {target}\n              field: id\n",
             1,
         )
 
-    schema = 'models:\n' + ''.join(model_entries)
+    schema = "models:\n" + "".join(model_entries)
     if unit_tests:
-        schema += 'unit_tests:\n' + ''.join(unit_tests)
+        schema += "unit_tests:\n" + "".join(unit_tests)
     return files, schema
 
 
@@ -2545,9 +2544,9 @@ class _NotebookWidgets:
 def _notebook_dbutils(values: dict[str, str]):
     """Builds the minimal `dbutils` object needed to execute the packaged notebook locally."""
     context = SimpleNamespace(
-        apiToken=lambda: _NotebookValue('token'),
-        apiUrl=lambda: _NotebookValue('https://example.databricks.com/'),
-        notebookPath=lambda: _NotebookValue('/Workspace/project/run_dbt_command.py'),
+        apiToken=lambda: _NotebookValue("token"),
+        apiUrl=lambda: _NotebookValue("https://example.databricks.com/"),
+        notebookPath=lambda: _NotebookValue("/Workspace/project/run_dbt_command.py"),
     )
     notebook = SimpleNamespace(getContext=lambda: context)
     backend = SimpleNamespace(notebook=lambda: notebook)
@@ -2557,34 +2556,34 @@ def _notebook_dbutils(values: dict[str, str]):
 
 def _run_shipped_notebook(monkeypatch, root: Path, selectors: tuple[str, ...]) -> dict:
     """Executes the complete packaged notebook and returns its module globals."""
-    select_args = ' '.join(f'--select {shlex.quote(selector)}' for selector in selectors)
+    select_args = " ".join(f"--select {shlex.quote(selector)}" for selector in selectors)
     command = (
-        f'dbt ls --quiet {select_args} --output json --output-keys unique_id ' f'--project-dir {shlex.quote(str(root))}'
+        f"dbt ls --quiet {select_args} --output json --output-keys unique_id --project-dir {shlex.quote(str(root))}"
     )
     values = {
-        'dbt_commands': json.dumps([command]),
-        'project_directory': '',
-        'profiles_directory': str(root),
+        "dbt_commands": json.dumps([command]),
+        "project_directory": "",
+        "profiles_directory": str(root),
     }
     runner_path = (
-        Path(__file__).resolve().parents[2] / 'src' / 'databricks_dbt_factory' / 'notebook' / 'run_dbt_command.py'
+        Path(__file__).resolve().parents[2] / "src" / "databricks_dbt_factory" / "notebook" / "run_dbt_command.py"
     )
     with monkeypatch.context() as execution:
         execution.chdir(root)
-        for name in ('DBT_ACCESS_TOKEN', 'DBT_HOST', 'DBT_TARGET_PATH', 'DBT_LOG_PATH'):
-            execution.setenv(name, os.environ.get(name, ''))
-        return runpy.run_path(str(runner_path), init_globals={'dbutils': _notebook_dbutils(values)})
+        for name in ("DBT_ACCESS_TOKEN", "DBT_HOST", "DBT_TARGET_PATH", "DBT_LOG_PATH"):
+            execution.setenv(name, os.environ.get(name, ""))
+        return runpy.run_path(str(runner_path), init_globals={"dbutils": _notebook_dbutils(values)})
 
 
 def _runner_result_ids(namespace: dict) -> tuple[str, ...]:
     """Returns the exact unique ids from the packaged notebook's final dbt invocation."""
-    result = namespace['result']
+    result = namespace["result"]
     assert result.success, result.exception
     assert isinstance(result.result, list)
-    return tuple(sorted(json.loads(entry)['unique_id'] for entry in result.result))
+    return tuple(sorted(json.loads(entry)["unique_id"] for entry in result.result))
 
 
-@pytest.mark.skipif(os.name == 'nt', reason='a backslash is a path separator on Windows')
+@pytest.mark.skipif(os.name == "nt", reason="a backslash is a path separator on Windows")
 def test_separator_free_posix_backslash_path_omits_the_ambiguous_file_term(tmp_path, monkeypatch):
     """
     A backslash-only path does not prove whether the manifest was parsed on Windows or whether the
@@ -2600,40 +2599,40 @@ models:
       - v: 1
         defined_in: 'we\\ird'
 """
-    _write_project(tmp_path, {'we\\ird.sql': MODEL_SQL}, schema_yml=schema_yml, model_search_path='')
+    _write_project(tmp_path, {"we\\ird.sql": MODEL_SQL}, schema_yml=schema_yml, model_search_path="")
     manifest = _parse(tmp_path)
-    unique_id = 'model.probe.orders.v1'
+    unique_id = "model.probe.orders.v1"
     resources = _resource_selectors(manifest, bundle_tests=False)
 
     assert len(resources) == 1
     _task_key, selectors, verb = resources[0]
-    assert verb == 'run'
+    assert verb == "run"
     assert len(selectors) == 1
-    assert all(not term.startswith('file:') for term in selectors[0].split(','))
-    assert _selected_unique_ids(tmp_path, selectors, 'model') == (unique_id,)
+    assert all(not term.startswith("file:") for term in selectors[0].split(","))
+    assert _selected_unique_ids(tmp_path, selectors, "model") == (unique_id,)
 
     namespace = _run_shipped_notebook(monkeypatch, tmp_path, selectors)
-    runner = namespace['runner']
+    runner = namespace["runner"]
     assert runner.manifest is not None
-    assert runner.manifest.nodes[unique_id].original_file_path == 'we\\ird.sql'
-    assert runner.manifest.flat_graph['nodes'][unique_id]['original_file_path'] == 'we\\ird.sql'
+    assert runner.manifest.nodes[unique_id].original_file_path == "we\\ird.sql"
+    assert runner.manifest.flat_graph["nodes"][unique_id]["original_file_path"] == "we\\ird.sql"
     assert _runner_result_ids(namespace) == (unique_id,)
 
 
 @pytest.mark.parametrize(
-    ('unique_id', 'simulate_windows'),
+    ("unique_id", "simulate_windows"),
     [
         # A model parsed on Windows: its `original_file_path` uses `\` throughout. The manifest does not
         # record that producer platform, so the factory omits `file:` and the Linux runner injects the
         # path unchanged rather than guessing how to reinterpret it.
-        pytest.param('model.probe.orders', True, id='windows-separators'),
+        pytest.param("model.probe.orders", True, id="windows-separators"),
         # A POSIX file whose name legitimately contains a backslash is the other interpretation the same
         # bare string can carry. The selector and injected manifest follow the same invariant rule.
         pytest.param(
-            'model.probe.we\\ird',
+            "model.probe.we\\ird",
             False,
-            id='posix-backslash-filename',
-            marks=pytest.mark.skipif(os.name == 'nt', reason='a backslash is a path separator on Windows'),
+            id="posix-backslash-filename",
+            marks=pytest.mark.skipif(os.name == "nt", reason="a backslash is a path separator on Windows"),
         ),
     ],
 )
@@ -2642,61 +2641,61 @@ def test_shipped_runner_injects_manifest_and_resolves_factory_selector(
 ):
     _write_project(
         tmp_path,
-        {'marts/orders.sql': MODEL_SQL, 'we\\ird.sql': MODEL_SQL},
+        {"marts/orders.sql": MODEL_SQL, "we\\ird.sql": MODEL_SQL},
     )
     manifest = _parse(tmp_path)
-    injected = Manifest.from_msgpack((tmp_path / 'target' / 'partial_parse.msgpack').read_bytes())
+    injected = Manifest.from_msgpack((tmp_path / "target" / "partial_parse.msgpack").read_bytes())
     if simulate_windows:
-        windows_path = manifest['nodes'][unique_id]['original_file_path'].replace('/', '\\')
-        manifest['nodes'][unique_id]['original_file_path'] = windows_path
+        windows_path = manifest["nodes"][unique_id]["original_file_path"].replace("/", "\\")
+        manifest["nodes"][unique_id]["original_file_path"] = windows_path
         injected.nodes[unique_id].original_file_path = windows_path
 
-    expected_path = manifest['nodes'][unique_id]['original_file_path']
+    expected_path = manifest["nodes"][unique_id]["original_file_path"]
     task_to_id = _task_key_to_unique_id(manifest, bundle_tests=False)
     selectors = next(
         selectors
         for task_key, selectors, verb in _resource_selectors(manifest, bundle_tests=False)
-        if verb == 'run' and task_to_id[task_key] == unique_id
+        if verb == "run" and task_to_id[task_key] == unique_id
     )
-    assert all(not term.startswith('file:') for term in selectors[0].split(','))
-    assert _selected_unique_ids(tmp_path, selectors, 'model') == (unique_id,)
+    assert all(not term.startswith("file:") for term in selectors[0].split(","))
+    assert _selected_unique_ids(tmp_path, selectors, "model") == (unique_id,)
 
     if simulate_windows:
         # Keep the native assertion above independent of the simulated-Windows artifact. dbt can reuse
         # `partial_parse.msgpack`, so writing the mangled copy earlier would let that check confirm the
         # same injected path the notebook is meant to validate.
-        (tmp_path / 'target' / 'partial_parse.msgpack').write_bytes(injected.to_msgpack())
+        (tmp_path / "target" / "partial_parse.msgpack").write_bytes(injected.to_msgpack())
 
     namespace = _run_shipped_notebook(monkeypatch, tmp_path, selectors)
-    runner = namespace['runner']
+    runner = namespace["runner"]
     assert runner.manifest is not None
     assert runner.manifest.nodes[unique_id].original_file_path == expected_path
-    assert runner.manifest.flat_graph['nodes'][unique_id]['original_file_path'] == expected_path
+    assert runner.manifest.flat_graph["nodes"][unique_id]["original_file_path"] == expected_path
     assert _runner_result_ids(namespace) == (unique_id,)
 
 
 @pytest.mark.parametrize(
-    ('artifact_contents', 'expects_fallback_message'),
+    ("artifact_contents", "expects_fallback_message"),
     [
-        pytest.param(None, False, id='missing'),
-        pytest.param(b'not a dbt msgpack artifact', True, id='corrupt'),
+        pytest.param(None, False, id="missing"),
+        pytest.param(b"not a dbt msgpack artifact", True, id="corrupt"),
     ],
 )
 def test_shipped_runner_falls_back_to_live_parse_when_manifest_is_unavailable(
     tmp_path, monkeypatch, capsys, artifact_contents, expects_fallback_message
 ):
     """Missing or unreadable pre-built manifests must still execute the exact factory selector."""
-    _write_project(tmp_path, {'orders.sql': MODEL_SQL})
+    _write_project(tmp_path, {"orders.sql": MODEL_SQL})
     manifest = _parse(tmp_path)
-    unique_id = 'model.probe.orders'
+    unique_id = "model.probe.orders"
     resources = _resource_selectors(manifest, bundle_tests=False)
 
     assert len(resources) == 1
     _task_key, selectors, verb = resources[0]
-    assert verb == 'run'
-    assert _selected_unique_ids(tmp_path, selectors, 'model') == (unique_id,)
+    assert verb == "run"
+    assert _selected_unique_ids(tmp_path, selectors, "model") == (unique_id,)
 
-    artifact = tmp_path / 'target' / 'partial_parse.msgpack'
+    artifact = tmp_path / "target" / "partial_parse.msgpack"
     if artifact_contents is None:
         artifact.unlink()
     else:
@@ -2704,14 +2703,14 @@ def test_shipped_runner_falls_back_to_live_parse_when_manifest_is_unavailable(
 
     namespace = _run_shipped_notebook(monkeypatch, tmp_path, selectors)
     output = capsys.readouterr().out
-    fallback_message = '[dbt-factory] manifest injection unavailable, falling back to dbt parse:'
+    fallback_message = "[dbt-factory] manifest injection unavailable, falling back to dbt parse:"
 
-    assert namespace['runner'].manifest is None
+    assert namespace["runner"].manifest is None
     assert _runner_result_ids(namespace) == (unique_id,)
     assert (fallback_message in output) is expects_fallback_message
 
 
-@pytest.mark.parametrize('seed', range(12))
+@pytest.mark.parametrize("seed", range(12))
 def test_random_gating_layouts_never_emit_a_cycle(tmp_path, seed):
     """
     Randomised ref/test/version wiring asserts that the safe-subset and first-frontier rules always emit

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -801,10 +801,10 @@ def test_failed_generation_preserves_an_existing_runner_notebook(monkeypatch, tm
 
 
 @pytest.mark.parametrize(
-    ('spec_body', 'note'),
+    ("spec_body", "note"),
     [
-        pytest.param(None, 'the input spec does not exist', id='missing-input-spec'),
-        pytest.param('not_a_job: true\n', 'the input spec holds no jobs', id='malformed-input-spec'),
+        pytest.param(None, "the input spec does not exist", id="missing-input-spec"),
+        pytest.param("not_a_job: true\n", "the input spec holds no jobs", id="malformed-input-spec"),
     ],
 )
 def test_input_spec_failure_preserves_an_existing_runner(monkeypatch, tmp_path, spec_body, note):

--- a/tests/test_dbt_factory.py
+++ b/tests/test_dbt_factory.py
@@ -45,15 +45,15 @@ def _model(
     # A versioned model's unique_id carries its version: model.<pkg>.<name>.v<N>.
     full_name = f"model.{package}.{name}" + (f".v{version}" if version is not None else "")
     info: dict = {
-        'resource_type': 'model',
-        'name': name,
-        'package_name': package,
-        'fqn': fqn or [package, name],
-        'original_file_path': path or f"models/{name}.sql",
-        'depends_on': {'nodes': depends_on or []},
+        "resource_type": "model",
+        "name": name,
+        "package_name": package,
+        "fqn": fqn or [package, name],
+        "original_file_path": path or f"models/{name}.sql",
+        "depends_on": {"nodes": depends_on or []},
     }
     if version is not None:
-        info['version'] = version
+        info["version"] = version
     return full_name, info
 
 
@@ -61,38 +61,38 @@ def _test(
     package: str,
     name: str,
     depends_on: list[str],
-    severity: str = 'error',
+    severity: str = "error",
     fqn: list[str] | None = None,
     path: str | None = None,
     test_name: str | None = None,
 ) -> tuple[str, dict]:
     full_name = f"test.{package}.{name}"
     info: dict = {
-        'resource_type': 'test',
-        'name': name,
-        'package_name': package,
-        'fqn': fqn or [package, name],
+        "resource_type": "test",
+        "name": name,
+        "package_name": package,
+        "fqn": fqn or [package, name],
         # dbt points a schema test at the .yml that declares it, so several tests share one path.
-        'original_file_path': path or f"models/{name}.yml",
-        'depends_on': {'nodes': depends_on},
-        'config': {'severity': severity},
+        "original_file_path": path or f"models/{name}.yml",
+        "depends_on": {"nodes": depends_on},
+        "config": {"severity": severity},
     }
     if test_name is not None:
         # A generic test carries the test type in `test_metadata.name` (`not_null`, `unique`, ...);
         # a singular test has no `test_metadata` at all.
-        info['test_metadata'] = {'name': test_name}
+        info["test_metadata"] = {"name": test_name}
     return full_name, info
 
 
 def _seed(package: str, name: str, fqn: list[str] | None = None, path: str | None = None) -> tuple[str, dict]:
     full_name = f"seed.{package}.{name}"
     return full_name, {
-        'resource_type': 'seed',
-        'name': name,
-        'package_name': package,
-        'fqn': fqn or [package, name],
-        'original_file_path': path or f"seeds/{name}.csv",
-        'depends_on': {'nodes': []},
+        "resource_type": "seed",
+        "name": name,
+        "package_name": package,
+        "fqn": fqn or [package, name],
+        "original_file_path": path or f"seeds/{name}.csv",
+        "depends_on": {"nodes": []},
     }
 
 
@@ -105,12 +105,12 @@ def _snapshot(
 ) -> tuple[str, dict]:
     full_name = f"snapshot.{package}.{name}"
     return full_name, {
-        'resource_type': 'snapshot',
-        'name': name,
-        'package_name': package,
-        'fqn': fqn or [package, name],
-        'original_file_path': path or f"snapshots/{name}.sql",
-        'depends_on': {'nodes': depends_on or []},
+        "resource_type": "snapshot",
+        "name": name,
+        "package_name": package,
+        "fqn": fqn or [package, name],
+        "original_file_path": path or f"snapshots/{name}.sql",
+        "depends_on": {"nodes": depends_on or []},
     }
 
 
@@ -118,24 +118,24 @@ def _analysis(package: str, name: str, fqn: list[str] | None = None, path: str |
     # dbt files analyses under `nodes` alongside models, but nothing selects them by default.
     full_name = f"analysis.{package}.{name}"
     return full_name, {
-        'resource_type': 'analysis',
-        'name': name,
-        'package_name': package,
-        'fqn': fqn or [package, 'analysis', name],
-        'original_file_path': path or f"analyses/{name}.sql",
-        'depends_on': {'nodes': []},
+        "resource_type": "analysis",
+        "name": name,
+        "package_name": package,
+        "fqn": fqn or [package, "analysis", name],
+        "original_file_path": path or f"analyses/{name}.sql",
+        "depends_on": {"nodes": []},
     }
 
 
 def _source(package: str, source_name: str, table: str, path: str | None = None) -> tuple[str, dict]:
     full_name = f"source.{package}.{source_name}.{table}"
     return full_name, {
-        'resource_type': 'source',
-        'name': table,
-        'source_name': source_name,
-        'package_name': package,
-        'fqn': [package, source_name, table],
-        'original_file_path': path or f"models/{source_name}.yml",
+        "resource_type": "source",
+        "name": table,
+        "source_name": source_name,
+        "package_name": package,
+        "fqn": [package, source_name, table],
+        "original_file_path": path or f"models/{source_name}.yml",
     }
 
 
@@ -155,95 +155,95 @@ def _unit_test(
     suffix = f"_v{version}" if version is not None else ""
     full_name = f"unit_test.{package}.{model}.{name}{suffix}"
     info: dict = {
-        'resource_type': 'unit_test',
-        'unique_id': full_name,
-        'name': name,
-        'model': model,
-        'package_name': package,
-        'fqn': fqn or [package, model, name],
+        "resource_type": "unit_test",
+        "unique_id": full_name,
+        "name": name,
+        "model": model,
+        "package_name": package,
+        "fqn": fqn or [package, model, name],
         # dbt declares unit tests in a .yml alongside the model.
-        'original_file_path': path or f"models/{model}_unit_tests.yml",
-        'depends_on': {'nodes': depends_on or [f"model.{package}.{model}"]},
+        "original_file_path": path or f"models/{model}_unit_tests.yml",
+        "depends_on": {"nodes": depends_on or [f"model.{package}.{model}"]},
     }
     if version is not None:
-        info['version'] = version
+        info["version"] = version
     return full_name, info
 
 
 def test_same_model_name_across_packages_produces_distinct_bundled_test_tasks(dbt_factory_bundled):
     nodes = dict(
         [
-            _model('pkg_a', 'customers'),
-            _model('pkg_b', 'customers'),
-            _model('pkg_a', 'orders', depends_on=['model.pkg_a.customers', 'model.pkg_b.customers']),
-            _test('pkg_a', 'unique_customers_id', ['model.pkg_a.customers']),
-            _test('pkg_b', 'not_null_customers_id', ['model.pkg_b.customers']),
+            _model("pkg_a", "customers"),
+            _model("pkg_b", "customers"),
+            _model("pkg_a", "orders", depends_on=["model.pkg_a.customers", "model.pkg_b.customers"]),
+            _test("pkg_a", "unique_customers_id", ["model.pkg_a.customers"]),
+            _test("pkg_b", "not_null_customers_id", ["model.pkg_b.customers"]),
         ]
     )
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert 'pkg_a_customers_test' in by_key
-    assert 'pkg_b_customers_test' in by_key
-    assert by_key['pkg_a_customers_test']['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg_a.unique_customers_id,package:pkg_a,file:unique_customers_id.yml,resource_type:test --target dev --indirect-selection empty'
+    assert "pkg_a_customers_test" in by_key
+    assert "pkg_b_customers_test" in by_key
+    assert by_key["pkg_a_customers_test"]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg_a.unique_customers_id,package:pkg_a,file:unique_customers_id.yml,resource_type:test --target dev --indirect-selection empty"
     ]
-    assert by_key['pkg_b_customers_test']['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg_b.not_null_customers_id,package:pkg_b,file:not_null_customers_id.yml,resource_type:test --target dev --indirect-selection empty'
+    assert by_key["pkg_b_customers_test"]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg_b.not_null_customers_id,package:pkg_b,file:not_null_customers_id.yml,resource_type:test --target dev --indirect-selection empty"
     ]
-    assert by_key['pkg_a_customers_test']['depends_on'] == [{'task_key': 'pkg_a_customers_model'}]
-    assert by_key['pkg_b_customers_test']['depends_on'] == [{'task_key': 'pkg_b_customers_model'}]
+    assert by_key["pkg_a_customers_test"]["depends_on"] == [{"task_key": "pkg_a_customers_model"}]
+    assert by_key["pkg_b_customers_test"]["depends_on"] == [{"task_key": "pkg_b_customers_model"}]
 
-    assert {dep['task_key'] for dep in by_key['orders_model']['depends_on']} == {
-        'pkg_a_customers_test',
-        'pkg_b_customers_test',
+    assert {dep["task_key"] for dep in by_key["orders_model"]["depends_on"]} == {
+        "pkg_a_customers_test",
+        "pkg_b_customers_test",
     }
 
 
 def test_bundled_test_groups_exact_selectors_by_mode_after_user_dbt_options():
     factory = DbtTestTaskFactory(
         DbtDependencyResolver(),
-        DbtTaskOptions(task_type='dbt'),
-        '--target dev --indirect-selection eager',
+        DbtTaskOptions(task_type="dbt"),
+        "--target dev --indirect-selection eager",
     )
 
     task = factory.create_bundled_task(
-        'orders_test',
+        "orders_test",
         {
-            'empty': ['fqn:pkg.unique_orders_id', 'fqn:pkg.not_null_orders_id'],
-            'cautious': ['fqn:pkg.orders,resource_type:model,fqn:pkg.check_orders'],
+            "empty": ["fqn:pkg.unique_orders_id", "fqn:pkg.not_null_orders_id"],
+            "cautious": ["fqn:pkg.orders,resource_type:model,fqn:pkg.check_orders"],
         },
-        'orders',
-        ['orders_model'],
+        "orders",
+        ["orders_model"],
     )
 
     assert task.commands == [
-        'dbt test --select fqn:pkg.not_null_orders_id --select fqn:pkg.unique_orders_id '
-        '--target dev --indirect-selection eager --indirect-selection empty',
-        'dbt test --select fqn:pkg.orders,resource_type:model,fqn:pkg.check_orders '
-        '--target dev --indirect-selection eager --indirect-selection cautious',
+        "dbt test --select fqn:pkg.not_null_orders_id --select fqn:pkg.unique_orders_id "
+        "--target dev --indirect-selection eager --indirect-selection empty",
+        "dbt test --select fqn:pkg.orders,resource_type:model,fqn:pkg.check_orders "
+        "--target dev --indirect-selection eager --indirect-selection cautious",
     ]
 
 
 def test_bundled_test_with_both_modes_and_deps_emits_three_commands():
     factory = DbtTestTaskFactory(
         DbtDependencyResolver(),
-        DbtTaskOptions(task_type='dbt', dbt_deps_enabled=True),
-        '--target dev',
+        DbtTaskOptions(task_type="dbt", dbt_deps_enabled=True),
+        "--target dev",
     )
 
     task = factory.create_bundled_task(
-        'orders_test',
-        {'empty': ['fqn:pkg.direct'], 'cautious': ['fqn:pkg.orders,fqn:pkg.scoped']},
-        'orders',
-        ['orders_model'],
+        "orders_test",
+        {"empty": ["fqn:pkg.direct"], "cautious": ["fqn:pkg.orders,fqn:pkg.scoped"]},
+        "orders",
+        ["orders_model"],
     )
 
     assert task.commands == [
-        'dbt deps --target dev',
-        'dbt test --select fqn:pkg.direct --target dev --indirect-selection empty',
-        'dbt test --select fqn:pkg.orders,fqn:pkg.scoped --target dev --indirect-selection cautious',
+        "dbt deps --target dev",
+        "dbt test --select fqn:pkg.direct --target dev --indirect-selection empty",
+        "dbt test --select fqn:pkg.orders,fqn:pkg.scoped --target dev --indirect-selection cautious",
     ]
 
 
@@ -253,96 +253,96 @@ def test_bundle_mode_model_depending_on_single_resource_test_does_not_raise(dbt_
     # dep during resolution.
     nodes = dict(
         [
-            _model('pkg', 'customers'),
-            _test('pkg', 'unique_customers_id', ['model.pkg.customers']),
-            _model('pkg', 'orders', depends_on=['test.pkg.unique_customers_id']),
+            _model("pkg", "customers"),
+            _test("pkg", "unique_customers_id", ["model.pkg.customers"]),
+            _model("pkg", "orders", depends_on=["test.pkg.unique_customers_id"]),
         ]
     )
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['orders_model']['depends_on'] == []
+    assert by_key["orders_model"]["depends_on"] == []
 
 
 def test_tests_on_seed_produce_task_and_gate_downstream(dbt_factory_bundled):
     nodes = dict(
         [
-            _seed('pkg', 'countries'),
-            _model('pkg', 'enriched', depends_on=['seed.pkg.countries']),
-            _test('pkg', 'unique_countries_code', ['seed.pkg.countries']),
+            _seed("pkg", "countries"),
+            _model("pkg", "enriched", depends_on=["seed.pkg.countries"]),
+            _test("pkg", "unique_countries_code", ["seed.pkg.countries"]),
         ]
     )
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert 'countries_test' in by_key
-    assert by_key['countries_test']['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg.unique_countries_code,package:pkg,file:unique_countries_code.yml,resource_type:test --target dev --indirect-selection empty'
+    assert "countries_test" in by_key
+    assert by_key["countries_test"]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg.unique_countries_code,package:pkg,file:unique_countries_code.yml,resource_type:test --target dev --indirect-selection empty"
     ]
-    assert by_key['countries_test']['depends_on'] == [{'task_key': 'countries_seed'}]
-    assert by_key['enriched_model']['depends_on'] == [{'task_key': 'countries_test'}]
+    assert by_key["countries_test"]["depends_on"] == [{"task_key": "countries_seed"}]
+    assert by_key["enriched_model"]["depends_on"] == [{"task_key": "countries_test"}]
 
 
 def test_tests_on_snapshot_produce_task_and_gate_downstream(dbt_factory_bundled):
     nodes = dict(
         [
-            _snapshot('pkg', 'orders_snap'),
-            _model('pkg', 'orders_history', depends_on=['snapshot.pkg.orders_snap']),
-            _test('pkg', 'not_null_orders_snap_id', ['snapshot.pkg.orders_snap']),
+            _snapshot("pkg", "orders_snap"),
+            _model("pkg", "orders_history", depends_on=["snapshot.pkg.orders_snap"]),
+            _test("pkg", "not_null_orders_snap_id", ["snapshot.pkg.orders_snap"]),
         ]
     )
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert 'orders_snap_test' in by_key
-    assert by_key['orders_snap_test']['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg.not_null_orders_snap_id,package:pkg,file:not_null_orders_snap_id.yml,resource_type:test --target dev --indirect-selection empty'
+    assert "orders_snap_test" in by_key
+    assert by_key["orders_snap_test"]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg.not_null_orders_snap_id,package:pkg,file:not_null_orders_snap_id.yml,resource_type:test --target dev --indirect-selection empty"
     ]
-    assert by_key['orders_snap_test']['depends_on'] == [{'task_key': 'orders_snap_snapshot'}]
-    assert by_key['orders_history_model']['depends_on'] == [{'task_key': 'orders_snap_test'}]
+    assert by_key["orders_snap_test"]["depends_on"] == [{"task_key": "orders_snap_snapshot"}]
+    assert by_key["orders_history_model"]["depends_on"] == [{"task_key": "orders_snap_test"}]
 
 
 def test_tests_on_source_produce_bundled_task(dbt_factory_bundled):
     nodes = dict(
         [
-            _test('pkg', 'unique_raw_customers_id', ['source.pkg.raw.customers']),
+            _test("pkg", "unique_raw_customers_id", ["source.pkg.raw.customers"]),
         ]
     )
-    sources = dict([_source('pkg', 'raw', 'customers')])
+    sources = dict([_source("pkg", "raw", "customers")])
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes, 'sources': sources})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes, "sources": sources})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert 'raw_customers_test' in by_key
-    assert by_key['raw_customers_test']['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg.unique_raw_customers_id,package:pkg,file:unique_raw_customers_id.yml,resource_type:test --target dev --indirect-selection empty'
+    assert "raw_customers_test" in by_key
+    assert by_key["raw_customers_test"]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg.unique_raw_customers_id,package:pkg,file:unique_raw_customers_id.yml,resource_type:test --target dev --indirect-selection empty"
     ]
-    assert by_key['raw_customers_test']['depends_on'] == []
+    assert by_key["raw_customers_test"]["depends_on"] == []
 
 
 @pytest.mark.parametrize(
-    ('consumer', 'task_key'),
+    ("consumer", "task_key"),
     [
-        pytest.param(_model, 'customers_model', id='model'),
-        pytest.param(_snapshot, 'customers_snapshot', id='snapshot'),
+        pytest.param(_model, "customers_model", id="model"),
+        pytest.param(_snapshot, "customers_snapshot", id="snapshot"),
     ],
 )
 def test_bundled_source_test_gates_consumers(dbt_factory_bundled, consumer, task_key):
-    source_id, source = _source('pkg', 'raw', 'customers')
+    source_id, source = _source("pkg", "raw", "customers")
     nodes = dict(
         [
-            _test('pkg', 'unique_raw_customers_id', [source_id]),
-            consumer('pkg', 'customers', depends_on=[source_id]),
+            _test("pkg", "unique_raw_customers_id", [source_id]),
+            consumer("pkg", "customers", depends_on=[source_id]),
         ]
     )
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes, 'sources': {source_id: source}})
-    by_key = {task['task_key']: task for task in tasks}
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes, "sources": {source_id: source}})
+    by_key = {task["task_key"]: task for task in tasks}
 
-    assert by_key[task_key]['depends_on'] == [{'task_key': 'raw_customers_test'}]
+    assert by_key[task_key]["depends_on"] == [{"task_key": "raw_customers_test"}]
 
 
 def test_flat_mode_emits_one_task_per_test_node_and_gates_downstream(dbt_factory):
@@ -350,29 +350,29 @@ def test_flat_mode_emits_one_task_per_test_node_and_gates_downstream(dbt_factory
     # failing `severity: error` test skips downstream via Databricks task failure.
     nodes = dict(
         [
-            _model('pkg', 'customers'),
-            _model('pkg', 'orders', depends_on=['model.pkg.customers']),
-            _test('pkg', 'unique_customers_id', ['model.pkg.customers']),
-            _test('pkg', 'not_null_customers_id', ['model.pkg.customers']),
+            _model("pkg", "customers"),
+            _model("pkg", "orders", depends_on=["model.pkg.customers"]),
+            _test("pkg", "unique_customers_id", ["model.pkg.customers"]),
+            _test("pkg", "not_null_customers_id", ["model.pkg.customers"]),
         ]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert 'unique_customers_id_test' in by_key
-    assert 'not_null_customers_id_test' in by_key
-    assert 'customers_test' not in by_key
+    assert "unique_customers_id_test" in by_key
+    assert "not_null_customers_id_test" in by_key
+    assert "customers_test" not in by_key
 
-    assert by_key['unique_customers_id_test']['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg.unique_customers_id,package:pkg,file:unique_customers_id.yml,resource_type:test --target dev --indirect-selection empty'
+    assert by_key["unique_customers_id_test"]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg.unique_customers_id,package:pkg,file:unique_customers_id.yml,resource_type:test --target dev --indirect-selection empty"
     ]
-    assert by_key['unique_customers_id_test']['depends_on'] == [{'task_key': 'customers_model'}]
+    assert by_key["unique_customers_id_test"]["depends_on"] == [{"task_key": "customers_model"}]
     # orders depends on customers AND every test attached to customers
-    assert {dep['task_key'] for dep in by_key['orders_model']['depends_on']} == {
-        'customers_model',
-        'unique_customers_id_test',
-        'not_null_customers_id_test',
+    assert {dep["task_key"] for dep in by_key["orders_model"]["depends_on"]} == {
+        "customers_model",
+        "unique_customers_id_test",
+        "not_null_customers_id_test",
     }
 
 
@@ -382,33 +382,33 @@ def test_flat_mode_cross_model_test_does_not_create_cycle(dbt_factory):
     # which itself depends on `orders` — a direct cycle.
     nodes = dict(
         [
-            _model('pkg', 'customers'),
-            _model('pkg', 'orders', depends_on=['model.pkg.customers']),
-            _model('pkg', 'payments', depends_on=['model.pkg.orders']),
-            _test('pkg', 'unique_customers_id', ['model.pkg.customers']),
+            _model("pkg", "customers"),
+            _model("pkg", "orders", depends_on=["model.pkg.customers"]),
+            _model("pkg", "payments", depends_on=["model.pkg.orders"]),
+            _test("pkg", "unique_customers_id", ["model.pkg.customers"]),
             _test(
-                'pkg',
-                'relationships_orders_customer_id__ref_customers',
-                ['model.pkg.orders', 'model.pkg.customers'],
+                "pkg",
+                "relationships_orders_customer_id__ref_customers",
+                ["model.pkg.orders", "model.pkg.customers"],
             ),
         ]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
     # orders depends on customers + unique_customers_id, but NOT on the relationship test
     # (that test references orders itself — including it would cycle)
-    assert {dep['task_key'] for dep in by_key['orders_model']['depends_on']} == {
-        'customers_model',
-        'unique_customers_id_test',
+    assert {dep["task_key"] for dep in by_key["orders_model"]["depends_on"]} == {
+        "customers_model",
+        "unique_customers_id_test",
     }
 
     # payments (downstream of orders) picks up the relationship test — safe, payments
     # transitively depends on both orders and customers (the test's refs)
-    payments_deps = {dep['task_key'] for dep in by_key['payments_model']['depends_on']}
-    assert 'orders_model' in payments_deps
-    assert 'relationships_orders_customer_id__ref_customers_test' in payments_deps
+    payments_deps = {dep["task_key"] for dep in by_key["payments_model"]["depends_on"]}
+    assert "orders_model" in payments_deps
+    assert "relationships_orders_customer_id__ref_customers_test" in payments_deps
 
 
 def test_flat_mode_transitive_cross_model_test_does_not_create_cycle(dbt_factory):
@@ -418,68 +418,68 @@ def test_flat_mode_transitive_cross_model_test_does_not_create_cycle(dbt_factory
     # (i.e. downstream of C) should get T.
     nodes = dict(
         [
-            _model('pkg', 'a'),
-            _model('pkg', 'b', depends_on=['model.pkg.a']),
-            _model('pkg', 'c', depends_on=['model.pkg.b']),
-            _model('pkg', 'd', depends_on=['model.pkg.c']),
-            _test('pkg', 'relationship_a_c', ['model.pkg.a', 'model.pkg.c']),
+            _model("pkg", "a"),
+            _model("pkg", "b", depends_on=["model.pkg.a"]),
+            _model("pkg", "c", depends_on=["model.pkg.b"]),
+            _model("pkg", "d", depends_on=["model.pkg.c"]),
+            _test("pkg", "relationship_a_c", ["model.pkg.a", "model.pkg.c"]),
         ]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
     # B's ancestors = {A}. Test T refs = {A, C}. C ∉ ancestors(B) → skip T.
-    assert by_key['b_model']['depends_on'] == [{'task_key': 'a_model'}]
+    assert by_key["b_model"]["depends_on"] == [{"task_key": "a_model"}]
     # C's ancestors = {A, B}. C IS in T.refs → skip T (direct self-reference).
-    assert by_key['c_model']['depends_on'] == [{'task_key': 'b_model'}]
+    assert by_key["c_model"]["depends_on"] == [{"task_key": "b_model"}]
     # D's ancestors = {A, B, C}. T.refs = {A, C} ⊆ ancestors(D) → add T.
-    d_deps = {dep['task_key'] for dep in by_key['d_model']['depends_on']}
-    assert d_deps == {'c_model', 'relationship_a_c_test'}
+    d_deps = {dep["task_key"] for dep in by_key["d_model"]["depends_on"]}
+    assert d_deps == {"c_model", "relationship_a_c_test"}
 
 
 def test_flat_mode_adds_test_gates_only_at_the_first_downstream_frontier(dbt_factory):
     nodes = {}
     for index in range(100):
-        name = f'm{index}'
-        dependencies = [f'model.pkg.m{index - 1}'] if index else []
-        nodes.update([_model('pkg', name, depends_on=dependencies)])
-        nodes.update([_test('pkg', f'quality_{name}', [f'model.pkg.{name}'])])
+        name = f"m{index}"
+        dependencies = [f"model.pkg.m{index - 1}"] if index else []
+        nodes.update([_model("pkg", name, depends_on=dependencies)])
+        nodes.update([_test("pkg", f"quality_{name}", [f"model.pkg.{name}"])])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {task['task_key']: task for task in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {task["task_key"]: task for task in tasks}
     gate_edges = []
     for task_key, task in by_key.items():
-        if not task_key.endswith('_model'):
+        if not task_key.endswith("_model"):
             continue
-        for dependency in task['depends_on']:
-            if dependency['task_key'].startswith('quality_'):
-                gate_edges.append((task_key, dependency['task_key']))
+        for dependency in task["depends_on"]:
+            if dependency["task_key"].startswith("quality_"):
+                gate_edges.append((task_key, dependency["task_key"]))
 
     assert len(gate_edges) == 99
-    assert gate_edges == [(f'm{index}_model', f'quality_m{index - 1}_test') for index in range(1, 100)]
+    assert gate_edges == [(f"m{index}_model", f"quality_m{index - 1}_test") for index in range(1, 100)]
 
 
 def test_flat_mode_handles_a_descending_999_model_chain_with_one_test(dbt_factory):
     nodes = dict(
         _model(
-            'pkg',
-            f'm{index:04d}',
-            depends_on=[f'model.pkg.m{index - 1:04d}'] if index else [],
+            "pkg",
+            f"m{index:04d}",
+            depends_on=[f"model.pkg.m{index - 1:04d}"] if index else [],
         )
         for index in reversed(range(999))
     )
-    nodes.update([_test('pkg', 'quality_m0000', ['model.pkg.m0000'])])
+    nodes.update([_test("pkg", "quality_m0000", ["model.pkg.m0000"])])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
 
     assert len(tasks) == 1_000
-    by_key = {task['task_key']: task for task in tasks}
-    assert by_key['m0001_model']['depends_on'] == [
-        {'task_key': 'm0000_model'},
-        {'task_key': 'quality_m0000_test'},
+    by_key = {task["task_key"]: task for task in tasks}
+    assert by_key["m0001_model"]["depends_on"] == [
+        {"task_key": "m0000_model"},
+        {"task_key": "quality_m0000_test"},
     ]
-    assert by_key['m0002_model']['depends_on'] == [{'task_key': 'm0001_model'}]
+    assert by_key["m0002_model"]["depends_on"] == [{"task_key": "m0001_model"}]
 
 
 def test_flat_mode_skips_ancestor_computation_when_no_tests_are_emitted(
@@ -487,38 +487,38 @@ def test_flat_mode_skips_ancestor_computation_when_no_tests_are_emitted(
 ):
     nodes = dict(
         _model(
-            'pkg',
-            f'm{index:04d}',
-            depends_on=[f'model.pkg.m{index - 1:04d}'] if index else [],
+            "pkg",
+            f"m{index:04d}",
+            depends_on=[f"model.pkg.m{index - 1:04d}"] if index else [],
         )
         for index in reversed(range(999))
     )
 
     def unexpected_ancestor_computation(*_args, **_kwargs):
-        pytest.fail('ancestor computation is unnecessary without emitted tests')
+        pytest.fail("ancestor computation is unnecessary without emitted tests")
 
-    monkeypatch.setattr(dbt_factory, '_compute_ancestors', unexpected_ancestor_computation)
+    monkeypatch.setattr(dbt_factory, "_compute_ancestors", unexpected_ancestor_computation)
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
 
     assert len(tasks) == 999
 
 
-@pytest.mark.parametrize('reverse_order', [False, True])
+@pytest.mark.parametrize("reverse_order", [False, True])
 def test_flat_mode_refuses_a_cyclic_manifest_with_a_deterministic_remedy(dbt_factory, reverse_order):
     entries = [
-        _model('pkg', 'a', depends_on=['model.pkg.b']),
-        _model('pkg', 'b', depends_on=['model.pkg.a']),
-        _test('pkg', 'quality_a', ['model.pkg.a']),
+        _model("pkg", "a", depends_on=["model.pkg.b"]),
+        _model("pkg", "b", depends_on=["model.pkg.a"]),
+        _test("pkg", "quality_a", ["model.pkg.a"]),
     ]
     nodes = dict(reversed(entries) if reverse_order else entries)
 
     with pytest.raises(ValueError) as error:
-        dbt_factory.create_tasks({'nodes': nodes})
+        dbt_factory.create_tasks({"nodes": nodes})
 
     assert str(error.value) == (
-        'Cannot compute test gates because the manifest contains the dependency cycle '
-        'model.pkg.a -> model.pkg.b -> model.pkg.a. Regenerate the manifest after removing the cycle.'
+        "Cannot compute test gates because the manifest contains the dependency cycle "
+        "model.pkg.a -> model.pkg.b -> model.pkg.a. Regenerate the manifest after removing the cycle."
     )
 
 
@@ -528,16 +528,16 @@ def test_first_frontier_union_caches_eligible_tests_for_converging_dependencies(
     """Eligibility is computed once per resource while converging frontiers inherit the full union."""
     nodes = dict(
         [
-            _model('pkg', 'a'),
-            _model('pkg', 'b'),
-            _model('pkg', 'left', depends_on=['model.pkg.a']),
-            _model('pkg', 'right', depends_on=['model.pkg.b']),
-            _model('pkg', 'join', depends_on=['model.pkg.left', 'model.pkg.right']),
-            _model('pkg', 'consumer_one', depends_on=['model.pkg.join']),
-            _model('pkg', 'consumer_two', depends_on=['model.pkg.join']),
-            _test('pkg', 'quality_a', ['model.pkg.a']),
-            _test('pkg', 'quality_b', ['model.pkg.b']),
-            _test('pkg', 'relationship_a_b', ['model.pkg.a', 'model.pkg.b']),
+            _model("pkg", "a"),
+            _model("pkg", "b"),
+            _model("pkg", "left", depends_on=["model.pkg.a"]),
+            _model("pkg", "right", depends_on=["model.pkg.b"]),
+            _model("pkg", "join", depends_on=["model.pkg.left", "model.pkg.right"]),
+            _model("pkg", "consumer_one", depends_on=["model.pkg.join"]),
+            _model("pkg", "consumer_two", depends_on=["model.pkg.join"]),
+            _test("pkg", "quality_a", ["model.pkg.a"]),
+            _test("pkg", "quality_b", ["model.pkg.b"]),
+            _test("pkg", "relationship_a_b", ["model.pkg.a", "model.pkg.b"]),
         ]
     )
     compute_ancestors = dbt_factory._compute_ancestors  # pylint: disable=protected-access
@@ -552,72 +552,72 @@ def test_first_frontier_union_caches_eligible_tests_for_converging_dependencies(
         )
         return dict(tracked_ancestors)
 
-    monkeypatch.setattr(DbtFactory, '_compute_ancestors', staticmethod(compute_tracked_ancestors))
+    monkeypatch.setattr(DbtFactory, "_compute_ancestors", staticmethod(compute_tracked_ancestors))
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    deps_by_key = {task['task_key']: [dependency['task_key'] for dependency in task['depends_on']] for task in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    deps_by_key = {task["task_key"]: [dependency["task_key"] for dependency in task["depends_on"]] for task in tasks}
 
-    assert deps_by_key['left_model'] == ['a_model', 'quality_a_test']
-    assert deps_by_key['right_model'] == ['b_model', 'quality_b_test']
-    assert deps_by_key['join_model'] == ['left_model', 'right_model', 'relationship_a_b_test']
-    assert deps_by_key['consumer_one_model'] == ['join_model']
-    assert deps_by_key['consumer_two_model'] == ['join_model']
-    assert tracked_ancestors['model.pkg.join'].iterations == 1
+    assert deps_by_key["left_model"] == ["a_model", "quality_a_test"]
+    assert deps_by_key["right_model"] == ["b_model", "quality_b_test"]
+    assert deps_by_key["join_model"] == ["left_model", "right_model", "relationship_a_b_test"]
+    assert deps_by_key["consumer_one_model"] == ["join_model"]
+    assert deps_by_key["consumer_two_model"] == ["join_model"]
+    assert tracked_ancestors["model.pkg.join"].iterations == 1
 
 
 def test_flat_mode_warn_severity_tests_gate_downstream(dbt_factory):
     nodes = dict(
         [
-            _model('pkg', 'customers'),
-            _model('pkg', 'orders', depends_on=['model.pkg.customers']),
-            _test('pkg', 'unique_customers_id', ['model.pkg.customers'], severity='warn'),
-            _test('pkg', 'not_null_customers_id', ['model.pkg.customers'], severity='error'),
+            _model("pkg", "customers"),
+            _model("pkg", "orders", depends_on=["model.pkg.customers"]),
+            _test("pkg", "unique_customers_id", ["model.pkg.customers"], severity="warn"),
+            _test("pkg", "not_null_customers_id", ["model.pkg.customers"], severity="error"),
         ]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert 'unique_customers_id_test' in by_key
-    assert 'not_null_customers_id_test' in by_key
+    assert "unique_customers_id_test" in by_key
+    assert "not_null_customers_id_test" in by_key
 
-    assert {dep['task_key'] for dep in by_key['orders_model']['depends_on']} == {
-        'customers_model',
-        'unique_customers_id_test',
-        'not_null_customers_id_test',
+    assert {dep["task_key"] for dep in by_key["orders_model"]["depends_on"]} == {
+        "customers_model",
+        "unique_customers_id_test",
+        "not_null_customers_id_test",
     }
 
 
 def test_flat_mode_test_on_seed_gates_on_seed(dbt_factory):
     nodes = dict(
         [
-            _seed('pkg', 'countries'),
-            _test('pkg', 'unique_countries_code', ['seed.pkg.countries']),
+            _seed("pkg", "countries"),
+            _test("pkg", "unique_countries_code", ["seed.pkg.countries"]),
         ]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['unique_countries_code_test']['depends_on'] == [{'task_key': 'countries_seed'}]
+    assert by_key["unique_countries_code_test"]["depends_on"] == [{"task_key": "countries_seed"}]
 
 
 def test_bundled_task_factory_assembles_commands(dbt_factory_bundled):
-    test_factory = dbt_factory_bundled.task_factories['test']
+    test_factory = dbt_factory_bundled.task_factories["test"]
     task = test_factory.create_bundled_task(
-        task_key='customers_test',
+        task_key="customers_test",
         selects_by_indirect_selection={
-            'empty': ['fqn:pkg.unique_customers_id', 'fqn:pkg.not_null_customers_id'],
+            "empty": ["fqn:pkg.unique_customers_id", "fqn:pkg.not_null_customers_id"],
         },
-        deps_command_name='customers',
-        depends_on=['customers_model'],
+        deps_command_name="customers",
+        depends_on=["customers_model"],
     )
-    assert task.task_key == 'customers_test'
+    assert task.task_key == "customers_test"
     assert task.commands == [
-        'dbt test --select fqn:pkg.not_null_customers_id --select fqn:pkg.unique_customers_id '
-        '--target dev --indirect-selection empty'
+        "dbt test --select fqn:pkg.not_null_customers_id --select fqn:pkg.unique_customers_id "
+        "--target dev --indirect-selection empty"
     ]
-    assert task.depends_on == ['customers_model']
+    assert task.depends_on == ["customers_model"]
 
 
 def test_cross_model_test_in_bundled_mode_is_emitted_as_standalone_task(dbt_factory_bundled):
@@ -626,58 +626,58 @@ def test_cross_model_test_in_bundled_mode_is_emitted_as_standalone_task(dbt_fact
     # It should emit its own task with deps on both referenced models.
     nodes = dict(
         [
-            _model('pkg', 'team_cities'),
-            _model('pkg', 'game_details', depends_on=['model.pkg.team_cities']),
-            _test('pkg', 'not_null_team_cities_name', ['model.pkg.team_cities']),
+            _model("pkg", "team_cities"),
+            _model("pkg", "game_details", depends_on=["model.pkg.team_cities"]),
+            _test("pkg", "not_null_team_cities_name", ["model.pkg.team_cities"]),
             _test(
-                'pkg',
-                'relationships_game_details_winner__team_city__ref_team_cities_',
-                ['model.pkg.game_details', 'model.pkg.team_cities'],
+                "pkg",
+                "relationships_game_details_winner__team_city__ref_team_cities_",
+                ["model.pkg.game_details", "model.pkg.team_cities"],
             ),
         ]
     )
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
     # Single-resource test → bundled by its exact selector.
-    assert 'team_cities_test' in by_key
-    assert by_key['team_cities_test']['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg.not_null_team_cities_name,package:pkg,file:not_null_team_cities_name.yml,resource_type:test --target dev --indirect-selection empty'
+    assert "team_cities_test" in by_key
+    assert by_key["team_cities_test"]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg.not_null_team_cities_name,package:pkg,file:not_null_team_cities_name.yml,resource_type:test --target dev --indirect-selection empty"
     ]
 
     # Cross-resource test → its own task, gated on both referenced models.
-    cross_test_key = 'relationships_game_details_winner__team_city__ref_team_cities__test'
+    cross_test_key = "relationships_game_details_winner__team_city__ref_team_cities__test"
     assert cross_test_key in by_key
-    assert by_key[cross_test_key]['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg.relationships_game_details_winner__team_city__ref_team_cities_,package:pkg,file:relationships_game_details_winner__team_city__ref_team_cities_.yml,resource_type:test --target dev --indirect-selection empty'
+    assert by_key[cross_test_key]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg.relationships_game_details_winner__team_city__ref_team_cities_,package:pkg,file:relationships_game_details_winner__team_city__ref_team_cities_.yml,resource_type:test --target dev --indirect-selection empty"
     ]
-    assert {dep['task_key'] for dep in by_key[cross_test_key]['depends_on']} == {
-        'team_cities_model',
-        'game_details_model',
+    assert {dep["task_key"] for dep in by_key[cross_test_key]["depends_on"]} == {
+        "team_cities_model",
+        "game_details_model",
     }
 
     # `game_details` has no single-resource tests, so no bundled `game_details_test` exists.
-    assert 'game_details_test' not in by_key
+    assert "game_details_test" not in by_key
 
 
 def test_single_package_bundled_test_uses_qualified_select(dbt_factory_bundled):
     nodes = dict(
         [
-            _model('pkg_a', 'customers'),
-            _model('pkg_a', 'orders', depends_on=['model.pkg_a.customers']),
-            _test('pkg_a', 'unique_customers_id', ['model.pkg_a.customers']),
+            _model("pkg_a", "customers"),
+            _model("pkg_a", "orders", depends_on=["model.pkg_a.customers"]),
+            _test("pkg_a", "unique_customers_id", ["model.pkg_a.customers"]),
         ]
     )
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert 'customers_test' in by_key
-    assert by_key['customers_test']['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg_a.unique_customers_id,package:pkg_a,file:unique_customers_id.yml,resource_type:test --target dev --indirect-selection empty'
+    assert "customers_test" in by_key
+    assert by_key["customers_test"]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg_a.unique_customers_id,package:pkg_a,file:unique_customers_id.yml,resource_type:test --target dev --indirect-selection empty"
     ]
-    assert by_key['orders_model']['depends_on'] == [{'task_key': 'customers_test'}]
+    assert by_key["orders_model"]["depends_on"] == [{"task_key": "customers_test"}]
 
 
 def test_duplicate_model_name_across_packages_selects_by_distinct_fqn(dbt_factory):
@@ -686,19 +686,19 @@ def test_duplicate_model_name_across_packages_selects_by_distinct_fqn(dbt_factor
     # keeps each task scoped to exactly its own node.
     nodes = dict(
         [
-            _model('pkg_a', 'customers'),
-            _model('pkg_b', 'customers'),
+            _model("pkg_a", "customers"),
+            _model("pkg_b", "customers"),
         ]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['pkg_a_customers_model']['dbt_task']['commands'] == [
-        'dbt run --select fqn:pkg_a.customers,package:pkg_a,file:customers.sql,resource_type:model --target dev'
+    assert by_key["pkg_a_customers_model"]["dbt_task"]["commands"] == [
+        "dbt run --select fqn:pkg_a.customers,package:pkg_a,file:customers.sql,resource_type:model --target dev"
     ]
-    assert by_key['pkg_b_customers_model']['dbt_task']['commands'] == [
-        'dbt run --select fqn:pkg_b.customers,package:pkg_b,file:customers.sql,resource_type:model --target dev'
+    assert by_key["pkg_b_customers_model"]["dbt_task"]["commands"] == [
+        "dbt run --select fqn:pkg_b.customers,package:pkg_b,file:customers.sql,resource_type:model --target dev"
     ]
 
 
@@ -707,44 +707,44 @@ def test_flat_mode_downstream_dep_rewired_to_disambiguated_collided_key(dbt_fact
     # disambiguated key `pkg_a_customers_model`. A plain `customers_model` here would be a dangling dep.
     nodes = dict(
         [
-            _model('pkg_a', 'customers'),
-            _model('pkg_b', 'customers'),
-            _model('pkg', 'orders', depends_on=['model.pkg_a.customers']),
+            _model("pkg_a", "customers"),
+            _model("pkg_b", "customers"),
+            _model("pkg", "orders", depends_on=["model.pkg_a.customers"]),
         ]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['orders_model']['depends_on'] == [{'task_key': 'pkg_a_customers_model'}]
+    assert by_key["orders_model"]["depends_on"] == [{"task_key": "pkg_a_customers_model"}]
 
 
 def test_model_in_subdirectory_selects_by_full_fqn_flat_mode(dbt_factory):
     # A model in a subdirectory has fqn [pkg, sub, name]. The select must be the full dotted fqn
     # `pkg.sub.name`, not `pkg.name` (which matches nothing).
-    nodes = dict([_model('pkg', 'stg_orders', fqn=['pkg', 'staging', 'stg_orders'])])
+    nodes = dict([_model("pkg", "stg_orders", fqn=["pkg", "staging", "stg_orders"])])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['stg_orders_model']['dbt_task']['commands'] == [
-        'dbt run --select fqn:pkg.staging.stg_orders,package:pkg,file:stg_orders.sql,resource_type:model --target dev'
+    assert by_key["stg_orders_model"]["dbt_task"]["commands"] == [
+        "dbt run --select fqn:pkg.staging.stg_orders,package:pkg,file:stg_orders.sql,resource_type:model --target dev"
     ]
 
 
 def test_model_in_subdirectory_bundles_the_exact_test_selector(dbt_factory_bundled):
     nodes = dict(
         [
-            _model('pkg', 'stg_orders', fqn=['pkg', 'staging', 'stg_orders']),
-            _test('pkg', 'unique_stg_orders_id', ['model.pkg.stg_orders']),
+            _model("pkg", "stg_orders", fqn=["pkg", "staging", "stg_orders"]),
+            _test("pkg", "unique_stg_orders_id", ["model.pkg.stg_orders"]),
         ]
     )
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['stg_orders_test']['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg.unique_stg_orders_id,package:pkg,file:unique_stg_orders_id.yml,resource_type:test --target dev --indirect-selection empty'
+    assert by_key["stg_orders_test"]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg.unique_stg_orders_id,package:pkg,file:unique_stg_orders_id.yml,resource_type:test --target dev --indirect-selection empty"
     ]
 
 
@@ -753,23 +753,23 @@ def test_flat_mode_unit_test_emits_task_and_gates_downstream(dbt_factory):
     # task selected by its full fqn, gated on the model it tests, and downstream models gate on it.
     nodes = dict(
         [
-            _model('pkg', 'orders', fqn=['pkg', 'staging', 'orders']),
-            _model('pkg', 'summary', depends_on=['model.pkg.orders'], fqn=['pkg', 'marts', 'summary']),
+            _model("pkg", "orders", fqn=["pkg", "staging", "orders"]),
+            _model("pkg", "summary", depends_on=["model.pkg.orders"], fqn=["pkg", "marts", "summary"]),
         ]
     )
-    unit_tests = dict([_unit_test('pkg', 'orders', 'test_totals', fqn=['pkg', 'staging', 'orders', 'test_totals'])])
+    unit_tests = dict([_unit_test("pkg", "orders", "test_totals", fqn=["pkg", "staging", "orders", "test_totals"])])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes, 'unit_tests': unit_tests})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes, "unit_tests": unit_tests})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    unit_test_key = 'unit_test_pkg_orders_test_totals'
-    assert by_key[unit_test_key]['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg.staging.orders.test_totals,package:pkg,file:orders_unit_tests.yml,resource_type:unit_test --target dev --indirect-selection empty'
+    unit_test_key = "unit_test_pkg_orders_test_totals"
+    assert by_key[unit_test_key]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg.staging.orders.test_totals,package:pkg,file:orders_unit_tests.yml,resource_type:unit_test --target dev --indirect-selection empty"
     ]
-    assert by_key[unit_test_key]['depends_on'] == [{'task_key': 'orders_model'}]
+    assert by_key[unit_test_key]["depends_on"] == [{"task_key": "orders_model"}]
     # summary (downstream of orders) gates on the unit test as well as the model
-    assert {dep['task_key'] for dep in by_key['summary_model']['depends_on']} == {
-        'orders_model',
+    assert {dep["task_key"] for dep in by_key["summary_model"]["depends_on"]} == {
+        "orders_model",
         unit_test_key,
     }
 
@@ -777,30 +777,30 @@ def test_flat_mode_unit_test_emits_task_and_gates_downstream(dbt_factory):
 def test_bundled_mode_model_with_only_unit_test_emits_bundled_task(dbt_factory_bundled):
     # A model whose only test is a unit test still gets a bundled `<model>_test` task with that exact
     # unit-test selector, so it is not silently dropped.
-    nodes = dict([_model('pkg', 'orders', fqn=['pkg', 'staging', 'orders'])])
-    unit_tests = dict([_unit_test('pkg', 'orders', 'test_totals', fqn=['pkg', 'staging', 'orders', 'test_totals'])])
+    nodes = dict([_model("pkg", "orders", fqn=["pkg", "staging", "orders"])])
+    unit_tests = dict([_unit_test("pkg", "orders", "test_totals", fqn=["pkg", "staging", "orders", "test_totals"])])
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes, 'unit_tests': unit_tests})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes, "unit_tests": unit_tests})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert 'orders_test' in by_key
-    assert by_key['orders_test']['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg.staging.orders.test_totals,package:pkg,file:orders_unit_tests.yml,resource_type:unit_test --target dev --indirect-selection empty'
+    assert "orders_test" in by_key
+    assert by_key["orders_test"]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg.staging.orders.test_totals,package:pkg,file:orders_unit_tests.yml,resource_type:unit_test --target dev --indirect-selection empty"
     ]
-    assert by_key['orders_test']['depends_on'] == [{'task_key': 'orders_model'}]
+    assert by_key["orders_test"]["depends_on"] == [{"task_key": "orders_model"}]
     # No standalone unit-test task in bundled mode — the bundled task covers it.
-    assert 'unit_test_pkg_orders_test_totals' not in by_key
+    assert "unit_test_pkg_orders_test_totals" not in by_key
 
 
 def test_flat_mode_unit_test_on_absent_model_is_skipped(dbt_factory):
     # A unit test whose target model is not in the manifest is skipped rather than emitting a
     # task that gates on a model task that never exists.
-    unit_tests = dict([_unit_test('pkg', 'missing', 'test_totals')])
+    unit_tests = dict([_unit_test("pkg", "missing", "test_totals")])
 
-    tasks = dbt_factory.create_tasks({'nodes': {}, 'unit_tests': unit_tests})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": {}, "unit_tests": unit_tests})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert 'unit_test_pkg_missing_test_totals' not in by_key
+    assert "unit_test_pkg_missing_test_totals" not in by_key
     assert by_key == {}
 
 
@@ -868,13 +868,13 @@ def test_select_intersects_fqn_package_and_file(dbt_factory):
     # descendants and, for a package node, matches via its package-stripped fqn; `package:` matches a
     # whole package; `file:` matches a base name in every package — so the intersection is what pins
     # one node. One rule for every resource, rather than a per-shape decision.
-    nodes = dict([_model('pkg', 'orders', fqn=['pkg', 'marts', 'orders'], path='models/marts/orders.sql')])
+    nodes = dict([_model("pkg", "orders", fqn=["pkg", "marts", "orders"], path="models/marts/orders.sql")])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['orders_model']['dbt_task']['commands'] == [
-        'dbt run --select fqn:pkg.marts.orders,package:pkg,file:orders.sql,resource_type:model --target dev'
+    assert by_key["orders_model"]["dbt_task"]["commands"] == [
+        "dbt run --select fqn:pkg.marts.orders,package:pkg,file:orders.sql,resource_type:model --target dev"
     ]
 
 
@@ -884,19 +884,19 @@ def test_select_of_nested_sibling_is_separated_by_its_file(dbt_factory):
     # `items` in orders' task and again in items' own, concurrently. `file:` separates them.
     nodes = dict(
         [
-            _model('pkg', 'orders', fqn=['pkg', 'marts', 'orders'], path='models/marts/orders.sql'),
-            _model('pkg', 'items', fqn=['pkg', 'marts', 'orders', 'items'], path='models/marts/orders/items.sql'),
+            _model("pkg", "orders", fqn=["pkg", "marts", "orders"], path="models/marts/orders.sql"),
+            _model("pkg", "items", fqn=["pkg", "marts", "orders", "items"], path="models/marts/orders/items.sql"),
         ]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['orders_model']['dbt_task']['commands'] == [
-        'dbt run --select fqn:pkg.marts.orders,package:pkg,file:orders.sql,resource_type:model --target dev'
+    assert by_key["orders_model"]["dbt_task"]["commands"] == [
+        "dbt run --select fqn:pkg.marts.orders,package:pkg,file:orders.sql,resource_type:model --target dev"
     ]
-    assert by_key['items_model']['dbt_task']['commands'] == [
-        'dbt run --select fqn:pkg.marts.orders.items,package:pkg,file:items.sql,resource_type:model --target dev'
+    assert by_key["items_model"]["dbt_task"]["commands"] == [
+        "dbt run --select fqn:pkg.marts.orders.items,package:pkg,file:items.sql,resource_type:model --target dev"
     ]
 
 
@@ -907,47 +907,47 @@ def test_select_of_package_node_is_separated_by_its_package(dbt_factory):
     # since both files are `alpha.sql`.
     nodes = dict(
         [
-            _model('probe', 'alpha', fqn=['probe', 'alpha'], path='models/alpha.sql'),
-            _model('other', 'alpha', fqn=['other', 'probe', 'alpha'], path='models/probe/alpha.sql'),
+            _model("probe", "alpha", fqn=["probe", "alpha"], path="models/alpha.sql"),
+            _model("other", "alpha", fqn=["other", "probe", "alpha"], path="models/probe/alpha.sql"),
         ]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    commands = {t['task_key']: t['dbt_task']['commands'][0] for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    commands = {t["task_key"]: t["dbt_task"]["commands"][0] for t in tasks}
 
     assert (
-        commands['probe_alpha_model']
-        == 'dbt run --select fqn:probe.alpha,package:probe,file:alpha.sql,resource_type:model --target dev'
+        commands["probe_alpha_model"]
+        == "dbt run --select fqn:probe.alpha,package:probe,file:alpha.sql,resource_type:model --target dev"
     )
-    assert commands['other_alpha_model'] == (
-        'dbt run --select fqn:other.probe.alpha,package:other,file:alpha.sql,resource_type:model --target dev'
+    assert commands["other_alpha_model"] == (
+        "dbt run --select fqn:other.probe.alpha,package:other,file:alpha.sql,resource_type:model --target dev"
     )
 
 
 def test_bundled_test_uses_the_tests_uniform_exact_selector(dbt_factory_bundled):
     nodes = dict(
         [
-            _model('pkg', 'orders', fqn=['pkg', 'marts', 'orders'], path='models/marts/orders.sql'),
-            _test('pkg', 'unique_orders_id', ['model.pkg.orders'], path='models/marts/schema.yml'),
+            _model("pkg", "orders", fqn=["pkg", "marts", "orders"], path="models/marts/orders.sql"),
+            _test("pkg", "unique_orders_id", ["model.pkg.orders"], path="models/marts/schema.yml"),
         ]
     )
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['orders_test']['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg.unique_orders_id,package:pkg,file:schema.yml,resource_type:test --target dev --indirect-selection empty'
+    assert by_key["orders_test"]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg.unique_orders_id,package:pkg,file:schema.yml,resource_type:test --target dev --indirect-selection empty"
     ]
 
 
 @pytest.mark.parametrize(
-    ('bad_segment', 'reason'),
+    ("bad_segment", "reason"),
     [
-        pytest.param('my orders', 'space is a union separator', id='space'),
-        pytest.param('orders,archive', 'comma is an intersection separator', id='comma'),
-        pytest.param('or[der]s', 'brackets are fnmatch syntax', id='brackets'),
-        pytest.param('star*model', 'star is fnmatch syntax', id='star'),
-        pytest.param('q?model', 'question mark is fnmatch syntax', id='question-mark'),
+        pytest.param("my orders", "space is a union separator", id="space"),
+        pytest.param("orders,archive", "comma is an intersection separator", id="comma"),
+        pytest.param("or[der]s", "brackets are fnmatch syntax", id="brackets"),
+        pytest.param("star*model", "star is fnmatch syntax", id="star"),
+        pytest.param("q?model", "question mark is fnmatch syntax", id="question-mark"),
     ],
 )
 def test_unusable_fqn_segment_is_dropped_but_other_terms_remain(dbt_factory, bad_segment, reason):
@@ -955,13 +955,13 @@ def test_unusable_fqn_segment_is_dropped_but_other_terms_remain(dbt_factory, bad
     # bare name. The remaining terms still address the node, so generation succeeds rather than failing
     # outright. (`reason` documents which dbt rule each character trips.)
     assert reason
-    nodes = dict([_model('pkg', 'orders', fqn=['pkg', bad_segment, 'orders'], path=f'models/{bad_segment}/orders.sql')])
+    nodes = dict([_model("pkg", "orders", fqn=["pkg", bad_segment, "orders"], path=f"models/{bad_segment}/orders.sql")])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['orders_model']['dbt_task']['commands'] == [
-        'dbt run --select fqn:orders,package:pkg,file:orders.sql,resource_type:model --target dev'
+    assert by_key["orders_model"]["dbt_task"]["commands"] == [
+        "dbt run --select fqn:orders,package:pkg,file:orders.sql,resource_type:model --target dev"
     ]
 
 
@@ -970,12 +970,12 @@ def test_colon_in_an_fqn_segment_is_kept_now_that_the_method_is_explicit(dbt_fac
     # name. Naming the method ourselves settles that: `fqn:pkg.colon:model.orders` matches literally —
     # verified with `dbt ls` on dbt 1.12.0 — so the fqn term survives and the node keeps its strongest
     # discriminator.
-    nodes = dict([_model('pkg', 'orders', fqn=['pkg', 'colon:model', 'orders'], path='models/colon:model/orders.sql')])
+    nodes = dict([_model("pkg", "orders", fqn=["pkg", "colon:model", "orders"], path="models/colon:model/orders.sql")])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
 
-    assert [t['dbt_task']['commands'][0] for t in tasks] == [
-        'dbt run --select fqn:pkg.colon:model.orders,package:pkg,file:orders.sql,resource_type:model --target dev'
+    assert [t["dbt_task"]["commands"][0] for t in tasks] == [
+        "dbt run --select fqn:pkg.colon:model.orders,package:pkg,file:orders.sql,resource_type:model --target dev"
     ]
 
 
@@ -986,10 +986,10 @@ def test_fqn_ending_in_a_graph_operator_is_refused(dbt_factory):
     # `package:`/`file:`, which address groups, so the resource cannot be addressed and generation
     # refuses. `package:pkg,file:orders+1.sql` happens to resolve to one node here — see
     # `test_file_name_alone_never_addresses_a_resource` for why we do not rely on that.
-    nodes = dict([_model('pkg', 'orders+1', fqn=['pkg', 'orders+1'], path='models/orders+1.sql')])
+    nodes = dict([_model("pkg", "orders+1", fqn=["pkg", "orders+1"], path="models/orders+1.sql")])
 
-    with pytest.raises(ValueError, match='Cannot generate a task for'):
-        dbt_factory.create_tasks({'nodes': nodes})
+    with pytest.raises(ValueError, match="Cannot generate a task for"):
+        dbt_factory.create_tasks({"nodes": nodes})
 
 
 def test_fqn_starting_with_a_numeric_graph_operator_keeps_its_fqn_term(dbt_factory):
@@ -997,13 +997,13 @@ def test_fqn_starting_with_a_numeric_graph_operator_keeps_its_fqn_term(dbt_facto
     # `probe.orders` (the sibling plus two levels of its parents) — a wrong-node hit, not an empty one.
     # Under an explicit `fqn:` it is literal, so the fqn term survives and stays exact. Both confirmed with
     # `dbt ls` on dbt 1.12.0.
-    nodes = dict([_model('pkg', '2+orders', fqn=['pkg', '2+orders'], path='models/2+orders.sql')])
+    nodes = dict([_model("pkg", "2+orders", fqn=["pkg", "2+orders"], path="models/2+orders.sql")])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['2+orders_model']['dbt_task']['commands'] == [
-        'dbt run --select fqn:pkg.2+orders,package:pkg,file:2+orders.sql,resource_type:model --target dev'
+    assert by_key["2+orders_model"]["dbt_task"]["commands"] == [
+        "dbt run --select fqn:pkg.2+orders,package:pkg,file:2+orders.sql,resource_type:model --target dev"
     ]
 
 
@@ -1018,26 +1018,26 @@ def test_name_fallback_ending_in_a_graph_operator_is_refused(dbt_factory):
     nodes = dict(
         [
             _test(
-                'pkg',
-                'orders+1',
-                ['model.pkg.a'],
-                fqn=['pkg', 'my dir', 'orders+1'],
-                path='models/my dir/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "orders+1",
+                ["model.pkg.a"],
+                fqn=["pkg", "my dir", "orders+1"],
+                path="models/my dir/schema.yml",
+                test_name="not_null",
             ),
             _test(
-                'pkg',
-                'not_null_b_id',
-                ['model.pkg.b'],
-                fqn=['pkg', 'my dir', 'not_null_b_id'],
-                path='models/my dir/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "not_null_b_id",
+                ["model.pkg.b"],
+                fqn=["pkg", "my dir", "not_null_b_id"],
+                path="models/my dir/schema.yml",
+                test_name="not_null",
             ),
         ]
     )
 
-    with pytest.raises(ValueError, match='Cannot generate a task for'):
-        dbt_factory.create_tasks({'nodes': nodes})
+    with pytest.raises(ValueError, match="Cannot generate a task for"):
+        dbt_factory.create_tasks({"nodes": nodes})
 
 
 def test_file_name_alone_never_addresses_a_resource(dbt_factory):
@@ -1049,66 +1049,66 @@ def test_file_name_alone_never_addresses_a_resource(dbt_factory):
     #
     # Deliberately stricter than dbt requires — `package:pkg,file:orders+1.sql` does resolve to one node,
     # confirmed with `dbt ls` on dbt 1.12.0 — and the error says to rename the file.
-    nodes = dict([_model('pkg', 'orders+1', fqn=['pkg', 'my dir', 'orders+1'], path='models/my dir/orders+1.sql')])
+    nodes = dict([_model("pkg", "orders+1", fqn=["pkg", "my dir", "orders+1"], path="models/my dir/orders+1.sql")])
 
-    with pytest.raises(ValueError, match='Cannot generate a task for'):
-        dbt_factory.create_tasks({'nodes': nodes})
+    with pytest.raises(ValueError, match="Cannot generate a task for"):
+        dbt_factory.create_tasks({"nodes": nodes})
 
 
 def test_source_with_a_graph_operator_uses_its_exact_test_selector(dbt_factory_bundled):
     # A bundle addresses the test node directly, so an unusable source selector does not matter when
     # the test itself has an exact selector.
-    nodes = dict([_test('pkg', 'source_not_null_raw_orders_id', ['source.pkg.raw.orders+1'])])
-    sources = dict([_source('pkg', 'raw', 'orders+1')])
+    nodes = dict([_test("pkg", "source_not_null_raw_orders_id", ["source.pkg.raw.orders+1"])])
+    sources = dict([_source("pkg", "raw", "orders+1")])
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes, 'sources': sources})
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes, "sources": sources})
 
-    assert tasks[0]['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg.source_not_null_raw_orders_id,package:pkg,file:source_not_null_raw_orders_id.yml,resource_type:test --target dev --indirect-selection empty'
+    assert tasks[0]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg.source_not_null_raw_orders_id,package:pkg,file:source_not_null_raw_orders_id.yml,resource_type:test --target dev --indirect-selection empty"
     ]
 
 
 def test_source_selector_keeps_an_operator_away_from_the_boundary(dbt_factory_bundled):
     # Only the boundary matters. `source:pkg.raw.2+ord` puts the `2+` mid-string, and dbt resolves it
     # exactly (verified with `dbt ls` on dbt 1.12.0), so refusing it would reject a working project.
-    nodes = dict([_test('pkg', 'source_not_null_raw_2_ord_id', ['source.pkg.raw.2+ord'])])
-    sources = dict([_source('pkg', 'raw', '2+ord')])
+    nodes = dict([_test("pkg", "source_not_null_raw_2_ord_id", ["source.pkg.raw.2+ord"])])
+    sources = dict([_source("pkg", "raw", "2+ord")])
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes, 'sources': sources})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes, "sources": sources})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['raw_2+ord_test']['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg.source_not_null_raw_2_ord_id,package:pkg,file:source_not_null_raw_2_ord_id.yml,resource_type:test --target dev --indirect-selection empty'
+    assert by_key["raw_2+ord_test"]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg.source_not_null_raw_2_ord_id,package:pkg,file:source_not_null_raw_2_ord_id.yml,resource_type:test --target dev --indirect-selection empty"
     ]
 
 
 def test_source_dynamic_reference_does_not_enter_an_exact_test_bundle(dbt_factory_bundled):
-    source_id, source = _source('pkg', '{{job', 'id}}')
-    nodes = dict([_test('pkg', 'source_not_null_raw_orders_id', [source_id])])
+    source_id, source = _source("pkg", "{{job", "id}}")
+    nodes = dict([_test("pkg", "source_not_null_raw_orders_id", [source_id])])
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes, 'sources': {source_id: source}})
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes, "sources": {source_id: source}})
 
-    command = tasks[0]['dbt_task']['commands'][0]
-    assert '{{job.id}}' not in command
-    assert command.endswith('--indirect-selection empty')
+    command = tasks[0]["dbt_task"]["commands"][0]
+    assert "{{job.id}}" not in command
+    assert command.endswith("--indirect-selection empty")
 
 
 def test_bundled_union_cannot_compose_a_dynamic_reference(dbt_factory_bundled):
     first_id, first = _test(
-        'pkg',
-        'a_check',
-        ['model.pkg.orders'],
-        test_name='kind{{',
+        "pkg",
+        "a_check",
+        ["model.pkg.orders"],
+        test_name="kind{{",
     )
     second_id, second = _test(
-        'pkg',
-        'b}}',
-        ['model.pkg.orders'],
+        "pkg",
+        "b}}",
+        ["model.pkg.orders"],
     )
-    nodes = dict([_model('pkg', 'orders'), (first_id, first), (second_id, second)])
+    nodes = dict([_model("pkg", "orders"), (first_id, first), (second_id, second)])
 
-    with pytest.raises(ValueError, match='final selector .* contains a Databricks dynamic value reference'):
-        dbt_factory_bundled.create_tasks({'nodes': nodes})
+    with pytest.raises(ValueError, match="final selector .* contains a Databricks dynamic value reference"):
+        dbt_factory_bundled.create_tasks({"nodes": nodes})
 
 
 def test_generation_fails_when_only_non_discriminating_terms_survive(dbt_factory):
@@ -1121,82 +1121,82 @@ def test_generation_fails_when_only_non_discriminating_terms_survive(dbt_factory
     nodes = dict(
         [
             _test(
-                'pkg',
-                'check[a]id',
-                ['model.pkg.a'],
-                fqn=['pkg', 'check[a]id'],
-                path='models/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "check[a]id",
+                ["model.pkg.a"],
+                fqn=["pkg", "check[a]id"],
+                path="models/schema.yml",
+                test_name="not_null",
             ),
             # The sibling that makes `file:schema.yml` ambiguous, exactly as dbt reports it.
             _test(
-                'pkg',
-                'not_null_b_id',
-                ['model.pkg.b'],
-                fqn=['pkg', 'not_null_b_id'],
-                path='models/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "not_null_b_id",
+                ["model.pkg.b"],
+                fqn=["pkg", "not_null_b_id"],
+                path="models/schema.yml",
+                test_name="not_null",
             ),
         ]
     )
 
-    with pytest.raises(ValueError, match='Cannot generate a task for'):
-        dbt_factory.create_tasks({'nodes': nodes})
+    with pytest.raises(ValueError, match="Cannot generate a task for"):
+        dbt_factory.create_tasks({"nodes": nodes})
 
 
 def test_ambiguous_test_with_a_missing_parent_is_refused(dbt_factory):
     nodes = dict(
         [
-            _model('pkg', 'a'),
-            _model('pkg', 'b'),
+            _model("pkg", "a"),
+            _model("pkg", "b"),
             _test(
-                'pkg',
-                'check',
-                ['model.pkg.a', 'model.pkg.missing'],
-                fqn=['pkg', 'check'],
-                path='models/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "check",
+                ["model.pkg.a", "model.pkg.missing"],
+                fqn=["pkg", "check"],
+                path="models/schema.yml",
+                test_name="not_null",
             ),
             _test(
-                'pkg',
-                'check.nested',
-                ['model.pkg.b'],
-                fqn=['pkg', 'check', 'nested'],
-                path='models/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "check.nested",
+                ["model.pkg.b"],
+                fqn=["pkg", "check", "nested"],
+                path="models/schema.yml",
+                test_name="not_null",
             ),
         ]
     )
 
-    with pytest.raises(ValueError, match='also runs'):
-        dbt_factory.create_tasks({'nodes': nodes})
+    with pytest.raises(ValueError, match="also runs"):
+        dbt_factory.create_tasks({"nodes": nodes})
 
 
 def test_ambiguous_test_with_only_a_missing_parent_is_refused(dbt_factory):
     nodes = dict(
         [
-            _model('pkg', 'b'),
+            _model("pkg", "b"),
             _test(
-                'pkg',
-                'check',
-                ['model.pkg.missing'],
-                fqn=['pkg', 'check'],
-                path='models/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "check",
+                ["model.pkg.missing"],
+                fqn=["pkg", "check"],
+                path="models/schema.yml",
+                test_name="not_null",
             ),
             _test(
-                'pkg',
-                'check.nested',
-                ['model.pkg.b'],
-                fqn=['pkg', 'check', 'nested'],
-                path='models/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "check.nested",
+                ["model.pkg.b"],
+                fqn=["pkg", "check", "nested"],
+                path="models/schema.yml",
+                test_name="not_null",
             ),
         ]
     )
 
-    with pytest.raises(ValueError, match='also runs'):
-        dbt_factory.create_tasks({'nodes': nodes})
+    with pytest.raises(ValueError, match="also runs"):
+        dbt_factory.create_tasks({"nodes": nodes})
 
 
 def test_bundled_ambiguous_test_with_a_missing_parent_is_refused_not_scoped_to_the_present_one(
@@ -1216,29 +1216,29 @@ def test_bundled_ambiguous_test_with_a_missing_parent_is_refused_not_scoped_to_t
     # future manifest that could.
     nodes = dict(
         [
-            _model('pkg', 'a'),
-            _model('pkg', 'b'),
+            _model("pkg", "a"),
+            _model("pkg", "b"),
             _test(
-                'pkg',
-                'check',
-                ['model.pkg.a', 'model.pkg.missing'],
-                fqn=['pkg', 'check'],
-                path='models/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "check",
+                ["model.pkg.a", "model.pkg.missing"],
+                fqn=["pkg", "check"],
+                path="models/schema.yml",
+                test_name="not_null",
             ),
             _test(
-                'pkg',
-                'check.nested',
-                ['model.pkg.b'],
-                fqn=['pkg', 'check', 'nested'],
-                path='models/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "check.nested",
+                ["model.pkg.b"],
+                fqn=["pkg", "check", "nested"],
+                path="models/schema.yml",
+                test_name="not_null",
             ),
         ]
     )
 
-    with pytest.raises(ValueError, match='also runs'):
-        dbt_factory_bundled.create_tasks({'nodes': nodes})
+    with pytest.raises(ValueError, match="also runs"):
+        dbt_factory_bundled.create_tasks({"nodes": nodes})
 
 
 def test_a_usable_name_still_rescues_an_unusable_fqn(dbt_factory):
@@ -1246,128 +1246,128 @@ def test_a_usable_name_still_rescues_an_unusable_fqn(dbt_factory):
     # directory kills the fqn, but `orders` is a fine selector and dbt matches a bare name against the
     # fqn's leaf, so these projects keep working — refusing them would reject any project with a space
     # in a directory name.
-    nodes = dict([_model('pkg', 'orders', fqn=['pkg', 'my dir', 'orders'], path='models/my dir/orders.sql')])
+    nodes = dict([_model("pkg", "orders", fqn=["pkg", "my dir", "orders"], path="models/my dir/orders.sql")])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
 
-    assert [t['dbt_task']['commands'][0] for t in tasks] == [
-        'dbt run --select fqn:orders,package:pkg,file:orders.sql,resource_type:model --target dev'
+    assert [t["dbt_task"]["commands"][0] for t in tasks] == [
+        "dbt run --select fqn:orders,package:pkg,file:orders.sql,resource_type:model --target dev"
     ]
 
 
 def test_graph_operator_inside_a_segment_is_kept(dbt_factory):
     # `@` and `+` are only operators at the selector's start/end. `pkg.+leading` is exact, verified
     # with `dbt ls`, so rejecting it would refuse a project dbt handles fine.
-    nodes = dict([_model('pkg', '+leading', fqn=['pkg', '+leading'], path='models/+leading.sql')])
+    nodes = dict([_model("pkg", "+leading", fqn=["pkg", "+leading"], path="models/+leading.sql")])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['+leading_model']['dbt_task']['commands'] == [
-        'dbt run --select fqn:pkg.+leading,package:pkg,file:+leading.sql,resource_type:model --target dev'
+    assert by_key["+leading_model"]["dbt_task"]["commands"] == [
+        "dbt run --select fqn:pkg.+leading,package:pkg,file:+leading.sql,resource_type:model --target dev"
     ]
 
 
 @pytest.mark.parametrize(
-    'name',
+    "name",
     [
-        pytest.param('orders{draft}', id='literal-braces'),
-        pytest.param('orders{{draft', id='unclosed-reference'),
-        pytest.param('ordersdraft}}', id='unopened-reference'),
-        pytest.param('orders{{draft}', id='mismatched-reference'),
+        pytest.param("orders{draft}", id="literal-braces"),
+        pytest.param("orders{{draft", id="unclosed-reference"),
+        pytest.param("ordersdraft}}", id="unopened-reference"),
+        pytest.param("orders{{draft}", id="mismatched-reference"),
     ],
 )
 def test_literal_and_incomplete_braces_are_valid_selector_text(dbt_factory, name):
-    nodes = dict([_model('pkg', name)])
+    nodes = dict([_model("pkg", name)])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
 
-    assert shlex.split(tasks[0]['dbt_task']['commands'][0]) == [
-        'dbt',
-        'run',
-        '--select',
-        f'fqn:pkg.{name},package:pkg,file:{name}.sql,resource_type:model',
-        '--target',
-        'dev',
+    assert shlex.split(tasks[0]["dbt_task"]["commands"][0]) == [
+        "dbt",
+        "run",
+        "--select",
+        f"fqn:pkg.{name},package:pkg,file:{name}.sql,resource_type:model",
+        "--target",
+        "dev",
     ]
 
 
 def test_complete_dynamic_reference_falls_back_or_refuses(dbt_factory):
     safe_name_nodes = dict(
-        [_model('pkg', 'orders', fqn=['pkg', '{{job.id}}', 'orders'], path='models/{{job.id}}/orders.sql')]
+        [_model("pkg", "orders", fqn=["pkg", "{{job.id}}", "orders"], path="models/{{job.id}}/orders.sql")]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': safe_name_nodes})
+    tasks = dbt_factory.create_tasks({"nodes": safe_name_nodes})
 
-    assert tasks[0]['dbt_task']['commands'] == [
-        'dbt run --select fqn:orders,package:pkg,file:orders.sql,resource_type:model --target dev'
+    assert tasks[0]["dbt_task"]["commands"] == [
+        "dbt run --select fqn:orders,package:pkg,file:orders.sql,resource_type:model --target dev"
     ]
 
-    unsafe_nodes = dict([_model('pkg', '{{job.id}}', path='models/{{job.id}}.sql')])
-    with pytest.raises(ValueError, match='Databricks dynamic value reference'):
-        dbt_factory.create_tasks({'nodes': unsafe_nodes})
+    unsafe_nodes = dict([_model("pkg", "{{job.id}}", path="models/{{job.id}}.sql")])
+    with pytest.raises(ValueError, match="Databricks dynamic value reference"):
+        dbt_factory.create_tasks({"nodes": unsafe_nodes})
 
 
 def test_selector_composition_drops_a_term_that_forms_a_dynamic_reference(dbt_factory):
     nodes = dict(
         [
-            _model('pkg', 'orders'),
+            _model("pkg", "orders"),
             _test(
-                'pkg',
-                'check{{',
-                ['model.pkg.orders'],
-                path='models/schema}}.yml',
-                test_name='not_null',
+                "pkg",
+                "check{{",
+                ["model.pkg.orders"],
+                path="models/schema}}.yml",
+                test_name="not_null",
             ),
         ]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
     command = next(
-        shlex.split(task['dbt_task']['commands'][0])
+        shlex.split(task["dbt_task"]["commands"][0])
         for task in tasks
-        if task['dbt_task']['commands'][0].startswith('dbt test')
+        if task["dbt_task"]["commands"][0].startswith("dbt test")
     )
-    select = command[command.index('--select') + 1]
+    select = command[command.index("--select") + 1]
 
-    assert select == 'fqn:pkg.check{{,package:pkg,resource_type:test,test_name:not_null'
+    assert select == "fqn:pkg.check{{,package:pkg,resource_type:test,test_name:not_null"
 
 
 def test_parent_scoped_selector_refuses_a_composed_dynamic_reference(dbt_factory):
     nodes = dict(
         [
-            _model('pkg', 'orders{{'),
-            _model('pkg', 'other'),
+            _model("pkg", "orders{{"),
+            _model("pkg", "other"),
             _test(
-                'pkg',
-                'check}}',
-                ['model.pkg.orders{{'],
-                path='models/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "check}}",
+                ["model.pkg.orders{{"],
+                path="models/schema.yml",
+                test_name="not_null",
             ),
             _test(
-                'pkg',
-                'check}}.nested',
-                ['model.pkg.other'],
-                fqn=['pkg', 'check}}', 'nested'],
-                path='models/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "check}}.nested",
+                ["model.pkg.other"],
+                fqn=["pkg", "check}}", "nested"],
+                path="models/schema.yml",
+                test_name="not_null",
             ),
         ]
     )
 
-    with pytest.raises(ValueError, match='Databricks dynamic value reference'):
-        dbt_factory.create_tasks({'nodes': nodes})
+    with pytest.raises(ValueError, match="Databricks dynamic value reference"):
+        dbt_factory.create_tasks({"nodes": nodes})
 
 
 def test_generation_fails_when_no_term_can_address_the_node(dbt_factory):
     # When the resource name itself is unusable, every term carries it — the fqn leaf, the file name,
     # and only `package:` survives, which matches the whole package. Emitting that would build every
     # model in the package, so generation fails loudly with the node and the remedy named.
-    nodes = dict([_model('pkg', 'or[der]s', fqn=['pkg', 'or[der]s'], path='models/or[der]s.sql')])
+    nodes = dict([_model("pkg", "or[der]s", fqn=["pkg", "or[der]s"], path="models/or[der]s.sql")])
 
-    with pytest.raises(ValueError, match='Cannot generate a task for'):
-        dbt_factory.create_tasks({'nodes': nodes})
+    with pytest.raises(ValueError, match="Cannot generate a task for"):
+        dbt_factory.create_tasks({"nodes": nodes})
 
 
 def test_same_type_tests_in_one_file_get_distinct_selectors(dbt_factory):
@@ -1377,33 +1377,33 @@ def test_same_type_tests_in_one_file_get_distinct_selectors(dbt_factory):
     # built, since each task depends only on its own. The node's own `name` separates them.
     nodes = dict(
         [
-            _model('pkg', 'a', fqn=['pkg', 'my tests', 'a'], path='models/my tests/a.sql'),
-            _model('pkg', 'b', fqn=['pkg', 'my tests', 'b'], path='models/my tests/b.sql'),
+            _model("pkg", "a", fqn=["pkg", "my tests", "a"], path="models/my tests/a.sql"),
+            _model("pkg", "b", fqn=["pkg", "my tests", "b"], path="models/my tests/b.sql"),
             _test(
-                'pkg',
-                'not_null_a_id',
-                ['model.pkg.a'],
-                fqn=['pkg', 'my tests', 'not_null_a_id'],
-                path='models/my tests/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "not_null_a_id",
+                ["model.pkg.a"],
+                fqn=["pkg", "my tests", "not_null_a_id"],
+                path="models/my tests/schema.yml",
+                test_name="not_null",
             ),
             _test(
-                'pkg',
-                'not_null_b_id',
-                ['model.pkg.b'],
-                fqn=['pkg', 'my tests', 'not_null_b_id'],
-                path='models/my tests/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "not_null_b_id",
+                ["model.pkg.b"],
+                fqn=["pkg", "my tests", "not_null_b_id"],
+                path="models/my tests/schema.yml",
+                test_name="not_null",
             ),
         ]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    commands = {t['task_key']: t['dbt_task']['commands'][0] for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    commands = {t["task_key"]: t["dbt_task"]["commands"][0] for t in tasks}
 
-    assert commands['not_null_a_id_test'] != commands['not_null_b_id_test']
-    assert commands['not_null_a_id_test'] == (
-        'dbt test --select fqn:not_null_a_id,package:pkg,file:schema.yml,resource_type:test,test_name:not_null --target dev --indirect-selection empty'
+    assert commands["not_null_a_id_test"] != commands["not_null_b_id_test"]
+    assert commands["not_null_a_id_test"] == (
+        "dbt test --select fqn:not_null_a_id,package:pkg,file:schema.yml,resource_type:test,test_name:not_null --target dev --indirect-selection empty"
     )
 
 
@@ -1413,23 +1413,23 @@ def test_data_test_selector_includes_its_test_name(dbt_factory):
     # `unique` in the same file.
     nodes = dict(
         [
-            _model('pkg', 'a', fqn=['pkg', 'marts', 'a'], path='models/marts/a.sql'),
+            _model("pkg", "a", fqn=["pkg", "marts", "a"], path="models/marts/a.sql"),
             _test(
-                'pkg',
-                'not_null_a_id',
-                ['model.pkg.a'],
-                fqn=['pkg', 'marts', 'not_null_a_id'],
-                path='models/marts/schema.yml',
-                test_name='not_null',
+                "pkg",
+                "not_null_a_id",
+                ["model.pkg.a"],
+                fqn=["pkg", "marts", "not_null_a_id"],
+                path="models/marts/schema.yml",
+                test_name="not_null",
             ),
         ]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['not_null_a_id_test']['dbt_task']['commands'] == [
-        'dbt test --select fqn:pkg.marts.not_null_a_id,package:pkg,file:schema.yml,resource_type:test,test_name:not_null --target dev --indirect-selection empty'
+    assert by_key["not_null_a_id_test"]["dbt_task"]["commands"] == [
+        "dbt test --select fqn:pkg.marts.not_null_a_id,package:pkg,file:schema.yml,resource_type:test,test_name:not_null --target dev --indirect-selection empty"
     ]
 
 
@@ -1442,26 +1442,26 @@ def test_singular_test_sharing_a_models_fqn_generates_now_that_selection_is_empt
     # Pinning `--indirect-selection empty` removes that entirely — verified with `dbt ls` on dbt 1.12.0,
     # where the same selector returns both tests under eager and only `test.probe.beta` under empty. So the
     # layout is addressable and no longer refused, even with the model carrying its own test.
-    model = _model('pkg', 'beta', fqn=['pkg', 'beta'], path='models/beta.sql')
-    singular = _test('pkg', 'beta', [], fqn=['pkg', 'beta'], path='tests/beta.sql')
-    attached = _test('pkg', 'not_null_beta_id', ['model.pkg.beta'], path='models/schema.yml', test_name='not_null')
+    model = _model("pkg", "beta", fqn=["pkg", "beta"], path="models/beta.sql")
+    singular = _test("pkg", "beta", [], fqn=["pkg", "beta"], path="tests/beta.sql")
+    attached = _test("pkg", "not_null_beta_id", ["model.pkg.beta"], path="models/schema.yml", test_name="not_null")
 
     commands = {
-        t['task_key']: t['dbt_task']['commands'][0]
-        for t in dbt_factory.create_tasks({'nodes': dict([model, singular, attached])})
+        t["task_key"]: t["dbt_task"]["commands"][0]
+        for t in dbt_factory.create_tasks({"nodes": dict([model, singular, attached])})
     }
 
     assert (
-        commands['beta_model']
-        == 'dbt run --select fqn:pkg.beta,package:pkg,file:beta.sql,resource_type:model --target dev'
+        commands["beta_model"]
+        == "dbt run --select fqn:pkg.beta,package:pkg,file:beta.sql,resource_type:model --target dev"
     )
-    assert commands['beta_test'] == (
-        'dbt test --select fqn:pkg.beta,package:pkg,file:beta.sql,resource_type:test'
-        ' --target dev --indirect-selection empty'
+    assert commands["beta_test"] == (
+        "dbt test --select fqn:pkg.beta,package:pkg,file:beta.sql,resource_type:test"
+        " --target dev --indirect-selection empty"
     )
-    assert commands['not_null_beta_id_test'] == (
-        'dbt test --select fqn:pkg.not_null_beta_id,package:pkg,file:schema.yml,resource_type:test,'
-        'test_name:not_null --target dev --indirect-selection empty'
+    assert commands["not_null_beta_id_test"] == (
+        "dbt test --select fqn:pkg.not_null_beta_id,package:pkg,file:schema.yml,resource_type:test,"
+        "test_name:not_null --target dev --indirect-selection empty"
     )
 
 
@@ -1469,58 +1469,58 @@ def test_selector_is_shell_quoted_when_a_name_contains_a_quote(dbt_factory):
     # `models/customer's.sql` is a legal dbt model. Unquoted, the notebook runner's `shlex.split`
     # raises `ValueError: No closing quotation` and the task dies before dbt runs, so the selector is
     # shell-quoted at command construction.
-    nodes = dict([_model('pkg', "customer's", fqn=['pkg', "customer's"], path="models/customer's.sql")])
+    nodes = dict([_model("pkg", "customer's", fqn=["pkg", "customer's"], path="models/customer's.sql")])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    command = tasks[0]['dbt_task']['commands'][0]
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    command = tasks[0]["dbt_task"]["commands"][0]
 
     assert shlex.split(command) == [
-        'dbt',
-        'run',
-        '--select',
+        "dbt",
+        "run",
+        "--select",
         "fqn:pkg.customer's,package:pkg,file:customer's.sql,resource_type:model",
-        '--target',
-        'dev',
+        "--target",
+        "dev",
     ]
 
 
 def test_select_falls_back_to_the_bare_name_when_the_node_has_no_fqn(dbt_factory):
     # dbt always emits an fqn, but a hand-rolled or truncated manifest may not. The other terms still
     # address the node, so no fqn simply means one fewer term.
-    node_id, info = _model('pkg', 'orders')
-    del info['fqn']
+    node_id, info = _model("pkg", "orders")
+    del info["fqn"]
 
-    tasks = dbt_factory.create_tasks({'nodes': {node_id: info}})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": {node_id: info}})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert by_key['orders_model']['dbt_task']['commands'] == [
-        'dbt run --select fqn:orders,package:pkg,file:orders.sql,resource_type:model --target dev'
+    assert by_key["orders_model"]["dbt_task"]["commands"] == [
+        "dbt run --select fqn:orders,package:pkg,file:orders.sql,resource_type:model --target dev"
     ]
 
 
 def test_bundled_source_with_an_unusable_name_uses_the_exact_test_selector(dbt_factory_bundled):
-    nodes = dict([_test('pkg', 'unique_raw_customers_id', ['source.pkg.raw,archive.customers'])])
-    sources = dict([_source('pkg', 'raw,archive', 'customers')])
+    nodes = dict([_test("pkg", "unique_raw_customers_id", ["source.pkg.raw,archive.customers"])])
+    sources = dict([_source("pkg", "raw,archive", "customers")])
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes, 'sources': sources})
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes, "sources": sources})
 
-    assert tasks[0]['dbt_task']['commands'][0].startswith('dbt test --select fqn:pkg.unique_raw_customers_id,')
+    assert tasks[0]["dbt_task"]["commands"][0].startswith("dbt test --select fqn:pkg.unique_raw_customers_id,")
 
 
 @pytest.mark.parametrize(
-    ('source_name', 'table'),
+    ("source_name", "table"),
     [
-        pytest.param('raw.v1', 'orders', id='dotted-source-name'),
-        pytest.param('raw', 'orders.v1', id='dotted-table-name'),
+        pytest.param("raw.v1", "orders", id="dotted-source-name"),
+        pytest.param("raw", "orders.v1", id="dotted-table-name"),
     ],
 )
 def test_bundled_source_with_a_dotted_part_uses_the_exact_test_selector(dbt_factory_bundled, source_name, table):
-    nodes = dict([_test('pkg', 'unique_raw_orders_id', [f"source.pkg.{source_name}.{table}"])])
-    sources = dict([_source('pkg', source_name, table)])
+    nodes = dict([_test("pkg", "unique_raw_orders_id", [f"source.pkg.{source_name}.{table}"])])
+    sources = dict([_source("pkg", source_name, table)])
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes, 'sources': sources})
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes, "sources": sources})
 
-    assert tasks[0]['dbt_task']['commands'][0].startswith('dbt test --select fqn:pkg.unique_raw_orders_id,')
+    assert tasks[0]["dbt_task"]["commands"][0].startswith("dbt test --select fqn:pkg.unique_raw_orders_id,")
 
 
 def test_disabled_node_in_the_manifest_gets_no_task(dbt_factory):
@@ -1529,33 +1529,33 @@ def test_disabled_node_in_the_manifest_gets_no_task(dbt_factory):
     # into `nodes` (config.enabled=False, depends_on.nodes=[]). dbt refuses to select it, and
     # `dbt test` on a zero-match selector still exits 0 -- so emitting a task for it produces a
     # green task that asserts nothing. Confirmed against dbt 1.12.0.
-    live_id, live_info = _test('pkg', 'not_null_orders_v2_id', ['model.pkg.orders.v2'], test_name='not_null')
-    dead_id, dead_info = _test('pkg', 'not_null_orders_v1_id', [], test_name='not_null')
-    dead_info['config']['enabled'] = False
-    nodes = dict([_model('pkg', 'orders', version=2), (live_id, live_info), (dead_id, dead_info)])
+    live_id, live_info = _test("pkg", "not_null_orders_v2_id", ["model.pkg.orders.v2"], test_name="not_null")
+    dead_id, dead_info = _test("pkg", "not_null_orders_v1_id", [], test_name="not_null")
+    dead_info["config"]["enabled"] = False
+    nodes = dict([_model("pkg", "orders", version=2), (live_id, live_info), (dead_id, dead_info)])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert 'not_null_orders_v1_id_test' not in by_key, 'a disabled test must not become a task'
-    assert 'not_null_orders_v2_id_test' in by_key
-    assert 'orders_v2_model' in by_key
+    assert "not_null_orders_v1_id_test" not in by_key, "a disabled test must not become a task"
+    assert "not_null_orders_v2_id_test" in by_key
+    assert "orders_v2_model" in by_key
 
 
 def test_disabled_node_is_not_a_dependency_or_a_bundled_test(dbt_factory_bundled):
     # The disabled test must also drop out of the bundling decision: were it counted, its model
     # would get a bundled `<model>_test` task gating downstream work on a test dbt will not run.
-    dead_id, dead_info = _test('pkg', 'not_null_orders_id', ['model.pkg.orders'], test_name='not_null')
-    dead_info['config']['enabled'] = False
+    dead_id, dead_info = _test("pkg", "not_null_orders_id", ["model.pkg.orders"], test_name="not_null")
+    dead_info["config"]["enabled"] = False
     nodes = dict(
-        [_model('pkg', 'orders'), _model('pkg', 'downstream', depends_on=['model.pkg.orders']), (dead_id, dead_info)]
+        [_model("pkg", "orders"), _model("pkg", "downstream", depends_on=["model.pkg.orders"]), (dead_id, dead_info)]
     )
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert 'orders_test' not in by_key, 'a disabled test must not produce a bundled test task'
-    assert by_key['downstream_model']['depends_on'] == [{'task_key': 'orders_model'}]
+    assert "orders_test" not in by_key, "a disabled test must not produce a bundled test task"
+    assert by_key["downstream_model"]["depends_on"] == [{"task_key": "orders_model"}]
 
 
 def test_flat_mode_unit_test_on_versioned_model_emits_task(dbt_factory):
@@ -1565,95 +1565,95 @@ def test_flat_mode_unit_test_on_versioned_model_emits_task(dbt_factory):
     # exist in the manifest, so the unit test would be silently dropped.
     nodes = dict(
         [
-            _model('pkg', 'dim', fqn=['pkg', 'marts', 'dim', 'v1'], version=1),
-            _model('pkg', 'dim', fqn=['pkg', 'marts', 'dim', 'v2'], version=2),
+            _model("pkg", "dim", fqn=["pkg", "marts", "dim", "v1"], version=1),
+            _model("pkg", "dim", fqn=["pkg", "marts", "dim", "v2"], version=2),
         ]
     )
     unit_tests = dict(
         [
             _unit_test(
-                'pkg',
-                'dim',
-                'ut_a',
-                fqn=['pkg', 'models', 'marts', 'dim', 'ut_a'],
-                depends_on=['model.pkg.dim.v1'],
+                "pkg",
+                "dim",
+                "ut_a",
+                fqn=["pkg", "models", "marts", "dim", "ut_a"],
+                depends_on=["model.pkg.dim.v1"],
                 version=1,
             ),
             _unit_test(
-                'pkg',
-                'dim',
-                'ut_a',
-                fqn=['pkg', 'models', 'marts', 'dim', 'ut_a'],
-                depends_on=['model.pkg.dim.v2'],
+                "pkg",
+                "dim",
+                "ut_a",
+                fqn=["pkg", "models", "marts", "dim", "ut_a"],
+                depends_on=["model.pkg.dim.v2"],
                 version=2,
             ),
         ]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes, 'unit_tests': unit_tests})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes, "unit_tests": unit_tests})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    unit_test_keys = sorted(key for key in by_key if key.startswith('unit_test_'))
-    assert unit_test_keys == ['unit_test_pkg_dim_ut_a_v1', 'unit_test_pkg_dim_ut_a_v2']
-    assert by_key['unit_test_pkg_dim_ut_a_v1']['depends_on'] == [{'task_key': 'dim_v1_model'}]
-    assert by_key['unit_test_pkg_dim_ut_a_v2']['depends_on'] == [{'task_key': 'dim_v2_model'}]
+    unit_test_keys = sorted(key for key in by_key if key.startswith("unit_test_"))
+    assert unit_test_keys == ["unit_test_pkg_dim_ut_a_v1", "unit_test_pkg_dim_ut_a_v2"]
+    assert by_key["unit_test_pkg_dim_ut_a_v1"]["depends_on"] == [{"task_key": "dim_v1_model"}]
+    assert by_key["unit_test_pkg_dim_ut_a_v2"]["depends_on"] == [{"task_key": "dim_v2_model"}]
     for task_key in unit_test_keys:
-        command = by_key[task_key]['dbt_task']['commands'][-1]
-        assert command.endswith('--indirect-selection cautious')
+        command = by_key[task_key]["dbt_task"]["commands"][-1]
+        assert command.endswith("--indirect-selection cautious")
 
 
 def test_bundled_mode_unit_test_on_versioned_model_emits_bundled_task(dbt_factory_bundled):
     # The resolved versioned model receives a bundle containing its unit-test node.
     nodes = dict(
         [
-            _model('pkg', 'dim', fqn=['pkg', 'marts', 'dim', 'v1'], version=1),
-            _model('pkg', 'dim', fqn=['pkg', 'marts', 'dim', 'v2'], version=2),
+            _model("pkg", "dim", fqn=["pkg", "marts", "dim", "v1"], version=1),
+            _model("pkg", "dim", fqn=["pkg", "marts", "dim", "v2"], version=2),
         ]
     )
     unit_tests = dict(
         [
             _unit_test(
-                'pkg',
-                'dim',
-                'ut_a_v2',
-                fqn=['pkg', 'models', 'marts', 'dim', 'ut_a'],
-                depends_on=['model.pkg.dim.v2'],
+                "pkg",
+                "dim",
+                "ut_a_v2",
+                fqn=["pkg", "models", "marts", "dim", "ut_a"],
+                depends_on=["model.pkg.dim.v2"],
             ),
         ]
     )
 
-    tasks = dbt_factory_bundled.create_tasks({'nodes': nodes, 'unit_tests': unit_tests})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory_bundled.create_tasks({"nodes": nodes, "unit_tests": unit_tests})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert 'dim_v2_test' in by_key
-    assert by_key['dim_v2_test']['depends_on'] == [{'task_key': 'dim_v2_model'}]
+    assert "dim_v2_test" in by_key
+    assert by_key["dim_v2_test"]["depends_on"] == [{"task_key": "dim_v2_model"}]
     # v1 has no tests at all, so it gets no bundled test task.
-    assert 'dim_v1_test' not in by_key
+    assert "dim_v1_test" not in by_key
 
 
 def test_unit_test_target_falls_back_to_model_field_when_depends_on_absent(dbt_factory):
     # A manifest written by an older dbt (or a hand-rolled one) may omit depends_on for a unit
     # test. The `model`/`package_name` reconstruction stays as a fallback so those still work.
-    nodes = dict([_model('pkg', 'orders', fqn=['pkg', 'staging', 'orders'])])
-    unit_test_id, unit_test_info = _unit_test('pkg', 'orders', 'test_totals')
-    del unit_test_info['depends_on']
+    nodes = dict([_model("pkg", "orders", fqn=["pkg", "staging", "orders"])])
+    unit_test_id, unit_test_info = _unit_test("pkg", "orders", "test_totals")
+    del unit_test_info["depends_on"]
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes, 'unit_tests': {unit_test_id: unit_test_info}})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes, "unit_tests": {unit_test_id: unit_test_info}})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert 'unit_test_pkg_orders_test_totals' in by_key
+    assert "unit_test_pkg_orders_test_totals" in by_key
 
 
 def test_single_segment_fqn_does_not_crash_generation(dbt_factory):
     # Matching retries with the node's package stripped, which for a one-segment fqn leaves an empty
     # list. dbt's `is_selected_node` indexes `fqn[-1]`, so the mirror must handle the empty case rather
     # than raise — otherwise a manifest holding such a node crashes generation instead of building it.
-    nodes = dict([_model('pkg', 'lonely', fqn=['lonely'])])
+    nodes = dict([_model("pkg", "lonely", fqn=["lonely"])])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
 
-    assert [t['dbt_task']['commands'][0] for t in tasks] == [
-        'dbt run --select fqn:lonely,package:pkg,file:lonely.sql,resource_type:model --target dev'
+    assert [t["dbt_task"]["commands"][0] for t in tasks] == [
+        "dbt run --select fqn:lonely,package:pkg,file:lonely.sql,resource_type:model --target dev"
     ]
 
 
@@ -1665,19 +1665,19 @@ def test_versioned_models_sharing_a_bare_name_still_generate(dbt_factory):
     # collision through elsewhere.
     nodes = dict(
         [
-            _model('pkg', 'orders', fqn=['pkg', 'orders', 'v1'], version=1, path='models/orders_v1.sql'),
-            _model('pkg', 'orders', fqn=['pkg', 'orders', 'v2'], version=2, path='models/orders_v2.sql'),
+            _model("pkg", "orders", fqn=["pkg", "orders", "v1"], version=1, path="models/orders_v1.sql"),
+            _model("pkg", "orders", fqn=["pkg", "orders", "v2"], version=2, path="models/orders_v2.sql"),
         ]
     )
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
-    commands = {t['task_key']: t['dbt_task']['commands'][0] for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
+    commands = {t["task_key"]: t["dbt_task"]["commands"][0] for t in tasks}
 
     assert commands == {
-        'orders_v1_model': 'dbt run --select fqn:pkg.orders.v1,package:pkg,file:orders_v1.sql,resource_type:model'
-        ' --target dev',
-        'orders_v2_model': 'dbt run --select fqn:pkg.orders.v2,package:pkg,file:orders_v2.sql,resource_type:model'
-        ' --target dev',
+        "orders_v1_model": "dbt run --select fqn:pkg.orders.v1,package:pkg,file:orders_v1.sql,resource_type:model"
+        " --target dev",
+        "orders_v2_model": "dbt run --select fqn:pkg.orders.v2,package:pkg,file:orders_v2.sql,resource_type:model"
+        " --target dev",
     }
 
 
@@ -1685,12 +1685,12 @@ def test_path_with_platform_dependent_basename_omits_the_file_term(dbt_factory):
     # The same bare string can be a Windows hierarchy or a literal POSIX file name, and manifest JSON
     # records no producer platform. `file:` is safe only when both interpretations yield the same base
     # name; the remaining terms are still exact for this node.
-    nodes = dict([_model('pkg', 'orders', fqn=['pkg', 'marts', 'orders'], path='models\\marts\\orders.sql')])
+    nodes = dict([_model("pkg", "orders", fqn=["pkg", "marts", "orders"], path="models\\marts\\orders.sql")])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
 
-    assert [t['dbt_task']['commands'][0] for t in tasks] == [
-        'dbt run --select fqn:pkg.marts.orders,package:pkg,resource_type:model --target dev'
+    assert [t["dbt_task"]["commands"][0] for t in tasks] == [
+        "dbt run --select fqn:pkg.marts.orders,package:pkg,resource_type:model --target dev"
     ]
 
 
@@ -1698,80 +1698,80 @@ def test_ambiguous_path_refuses_an_fqn_prefix_collision_after_dropping_file(dbt_
     """A non-portable `file:` term cannot be used to hide an FQN-prefix collision."""
     nodes = dict(
         [
-            _model('pkg', 'a', fqn=['pkg', 'a'], path='models\\a.sql'),
-            _model('pkg', 'b', fqn=['pkg', 'a', 'b'], path='models\\a\\b.sql'),
+            _model("pkg", "a", fqn=["pkg", "a"], path="models\\a.sql"),
+            _model("pkg", "b", fqn=["pkg", "a", "b"], path="models\\a\\b.sql"),
         ]
     )
 
-    with pytest.raises(ValueError, match=r'also runs model\.pkg\.b'):
-        dbt_factory.create_tasks({'nodes': nodes})
+    with pytest.raises(ValueError, match=r"also runs model\.pkg\.b"):
+        dbt_factory.create_tasks({"nodes": nodes})
 
 
 def test_file_exactness_considers_every_basename_of_an_ambiguous_peer():
     """A safe `file:` term must account for either interpretation of another node's path."""
     _, safe = _test(
-        'pkg',
-        'check',
-        ['model.pkg.a', 'model.pkg.b'],
-        path='models/right.yml',
-        test_name='relationships',
+        "pkg",
+        "check",
+        ["model.pkg.a", "model.pkg.b"],
+        path="models/right.yml",
+        test_name="relationships",
     )
     _, ambiguous = _test(
-        'pkg',
-        'check',
-        ['model.pkg.c', 'model.pkg.d'],
-        path='models\\other\\right.yml',
-        test_name='relationships',
+        "pkg",
+        "check",
+        ["model.pkg.c", "model.pkg.d"],
+        path="models\\other\\right.yml",
+        test_name="relationships",
     )
     peers = DbtFactory._selector_index(  # pylint: disable=protected-access
-        {'test.pkg.check.safe': safe, 'test.pkg.check.ambiguous': ambiguous}
+        {"test.pkg.check.safe": safe, "test.pkg.check.ambiguous": ambiguous}
     )
 
-    with pytest.raises(ValueError, match='also runs test.pkg.check.ambiguous'):
+    with pytest.raises(ValueError, match="also runs test.pkg.check.ambiguous"):
         DbtFactory._node_select(safe, peers=peers)  # pylint: disable=protected-access
 
 
 def test_unit_test_clone_is_emitted_when_its_model_version_is_present(dbt_factory):
     # dbt omits a clone for a disabled model version, so a manifest may contain only one clone of a
     # versioned unit test. The remaining clone is emitted against its exact model version.
-    nodes = dict([_model('pkg', 'orders', fqn=['pkg', 'orders', 'v2'], version=2, path='models/orders_v2.sql')])
-    unit_tests = dict([_unit_test('pkg', 'orders', 'ut_orders', depends_on=['model.pkg.orders.v2'], version=2)])
+    nodes = dict([_model("pkg", "orders", fqn=["pkg", "orders", "v2"], version=2, path="models/orders_v2.sql")])
+    unit_tests = dict([_unit_test("pkg", "orders", "ut_orders", depends_on=["model.pkg.orders.v2"], version=2)])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes, 'unit_tests': unit_tests})
-    by_key = {t['task_key']: t for t in tasks}
+    tasks = dbt_factory.create_tasks({"nodes": nodes, "unit_tests": unit_tests})
+    by_key = {t["task_key"]: t for t in tasks}
 
-    assert sorted(key for key in by_key if key.startswith('unit_test_')) == ['unit_test_pkg_orders_ut_orders_v2']
-    assert by_key['unit_test_pkg_orders_ut_orders_v2']['depends_on'] == [{'task_key': 'orders_v2_model'}]
+    assert sorted(key for key in by_key if key.startswith("unit_test_")) == ["unit_test_pkg_orders_ut_orders_v2"]
+    assert by_key["unit_test_pkg_orders_ut_orders_v2"]["depends_on"] == [{"task_key": "orders_v2_model"}]
 
 
 def test_node_passed_as_a_copy_is_not_its_own_collision(dbt_factory):
     # `_assert_exact` recognises the node by object identity *or* `unique_id`. Identity alone would make
     # a node passed as a copy count as colliding with itself, refusing a perfectly addressable resource.
     # Guards the robustness of that check rather than a dbt behaviour.
-    node_id, node = _model('pkg', 'orders')
-    node['unique_id'] = node_id
-    manifest = {'nodes': {node_id: dict(node)}}  # a *copy* under the same id
+    node_id, node = _model("pkg", "orders")
+    node["unique_id"] = node_id
+    manifest = {"nodes": {node_id: dict(node)}}  # a *copy* under the same id
 
     tasks = dbt_factory.create_tasks(manifest)
 
-    assert [t['dbt_task']['commands'][0] for t in tasks] == [
-        'dbt run --select fqn:pkg.orders,package:pkg,file:orders.sql,resource_type:model --target dev'
+    assert [t["dbt_task"]["commands"][0] for t in tasks] == [
+        "dbt run --select fqn:pkg.orders,package:pkg,file:orders.sql,resource_type:model --target dev"
     ]
 
 
 def test_public_factory_allows_exactly_one_thousand_tasks(dbt_factory):
-    nodes = dict(_model('pkg', f'model_{index:04d}') for index in range(1_000))
+    nodes = dict(_model("pkg", f"model_{index:04d}") for index in range(1_000))
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
 
     assert len(tasks) == 1_000
 
 
 def test_public_factory_rejects_more_than_one_thousand_tasks(dbt_factory):
-    nodes = dict(_model('pkg', f'model_{index:04d}') for index in range(1_001))
+    nodes = dict(_model("pkg", f"model_{index:04d}") for index in range(1_001))
 
-    with pytest.raises(ValueError, match=r'at most 1,000 tasks.*1,001'):
-        dbt_factory.create_tasks({'nodes': nodes})
+    with pytest.raises(ValueError, match=r"at most 1,000 tasks.*1,001"):
+        dbt_factory.create_tasks({"nodes": nodes})
 
 
 # The selector-index test reaches into internals because "scan every peer" has no public surface.
@@ -1784,11 +1784,11 @@ def test_selector_index_narrowing_matches_a_full_scan(dbt_factory):
     # `schema.yml`, and a file whose stem is another file's name (`a.yml` / `a.yml.yml`).
     peers = dict(
         [
-            _model('pkg', 'orders', fqn=['pkg', 'orders', 'v1'], version=1, path='models/orders_v1.sql'),
-            _model('pkg', 'orders.items', fqn=['pkg', 'orders.items'], path='models/a.yml.yml'),
-            _model('pkg', 'items', fqn=['pkg', 'orders', 'items'], path='models/a.yml'),
-            _test('pkg', 'chk', ['model.pkg.items'], path='models/schema.yml', test_name='not_null'),
-            _test('pkg', 'chk.nested', ['model.pkg.orders.items'], path='models/schema.yml', test_name='not_null'),
+            _model("pkg", "orders", fqn=["pkg", "orders", "v1"], version=1, path="models/orders_v1.sql"),
+            _model("pkg", "orders.items", fqn=["pkg", "orders.items"], path="models/a.yml.yml"),
+            _model("pkg", "items", fqn=["pkg", "orders", "items"], path="models/a.yml"),
+            _test("pkg", "chk", ["model.pkg.items"], path="models/schema.yml", test_name="not_null"),
+            _test("pkg", "chk.nested", ["model.pkg.orders.items"], path="models/schema.yml", test_name="not_null"),
         ]
     )
     index = DbtFactory._selector_index(peers)
@@ -1797,26 +1797,26 @@ def test_selector_index_narrowing_matches_a_full_scan(dbt_factory):
         select = DbtFactory._node_select(info)
         scanned = sorted(DbtFactory._matching_ids(select, peers))
         narrowed = sorted(DbtFactory._matching_ids(select, index))
-        assert narrowed == scanned, f'{select!r} narrowed to {narrowed}, full scan gives {scanned}'
+        assert narrowed == scanned, f"{select!r} narrowed to {narrowed}, full scan gives {scanned}"
 
 
 def test_fqn_index_narrows_a_large_manifest_when_file_terms_are_ambiguous():
     """An exact FQN remains an efficient index key when platform-dependent paths omit `file:`."""
     peers = dict(
         _model(
-            'pkg',
-            f'model_{index:04d}',
-            fqn=['pkg', 'marts', f'model_{index:04d}'],
-            path=f'models\\marts\\model_{index:04d}.sql',
+            "pkg",
+            f"model_{index:04d}",
+            fqn=["pkg", "marts", f"model_{index:04d}"],
+            path=f"models\\marts\\model_{index:04d}.sql",
         )
         for index in range(1_000)
     )
     index = DbtFactory._selector_index(peers)
-    target_id = 'model.pkg.model_0500'
+    target_id = "model.pkg.model_0500"
     select = DbtFactory._node_select(peers[target_id])
 
-    assert 'file:' not in select
-    assert set(index.narrow(select.split(','))) == {target_id}
+    assert "file:" not in select
+    assert set(index.narrow(select.split(","))) == {target_id}
 
 
 def _random_model_layout(seed: int, size: int) -> dict:
@@ -1830,8 +1830,8 @@ def _random_model_layout(seed: int, size: int) -> dict:
     divergence between the three would surface.
     """
     rnd = random.Random(seed)
-    packages = ['pkg', 'shop', 'a']
-    words = ['orders', 'items', 'raw', 'a', 'b', 'dim']
+    packages = ["pkg", "shop", "a"]
+    words = ["orders", "items", "raw", "a", "b", "dim"]
     peers: dict = {}
     for _ in range(size):
         pkg = rnd.choice(packages)
@@ -1839,13 +1839,13 @@ def _random_model_layout(seed: int, size: int) -> dict:
         if rnd.random() < 0.25 and len(segments) >= 2:
             # A versioned model: dbt clones the version onto the fqn leaf (`['pkg', 'orders', 'v1']`).
             version = rnd.randint(1, 3)
-            full_name, info = _model(pkg, segments[-1], fqn=[pkg, *segments, f'v{version}'], version=version)
+            full_name, info = _model(pkg, segments[-1], fqn=[pkg, *segments, f"v{version}"], version=version)
         else:
             # Sometimes a dotted name, so the flattened fqn is longer than the raw one.
-            name = '.'.join(segments) if rnd.random() < 0.3 else segments[-1]
+            name = ".".join(segments) if rnd.random() < 0.3 else segments[-1]
             full_name, info = _model(pkg, name, fqn=[pkg, *segments])
         while full_name in peers:  # keep ids distinct without disturbing the node's fqn/name
-            full_name += '_'
+            full_name += "_"
         peers[full_name] = info
     return peers
 
@@ -1854,20 +1854,20 @@ def _fqn_terms_from(info: dict) -> set[str]:
     """Every fqn term dbt could plausibly address this node by — contiguous fqn slices (raw and
     flattened), the versioned `_`-join, and the bare name — so the term pool exercises the leaf
     shortcut, the positional walk, the package-stripped retry, and the versioned match."""
-    fqn = info.get('fqn') or []
+    fqn = info.get("fqn") or []
     terms: set[str] = set()
-    if info.get('name'):
-        terms.add(info['name'])
+    if info.get("name"):
+        terms.add(info["name"])
     for parts in (fqn, DbtFactory._flat_fqn(fqn)):
         for start in range(len(parts)):
             for end in range(start + 1, len(parts) + 1):
-                terms.add('.'.join(parts[start:end]))
+                terms.add(".".join(parts[start:end]))
         if len(parts) >= 2:
-            terms.add('_'.join(parts[-2:]))
+            terms.add("_".join(parts[-2:]))
     return terms
 
 
-@pytest.mark.parametrize('seed', range(8))
+@pytest.mark.parametrize("seed", range(8))
 def test_fqn_index_bucket_is_a_superset_of_the_truth_over_random_layouts(seed):
     # The soundness invariant behind the whole exactness check: whenever the truth predicate says an
     # fqn term matches a node, the index must file that node in the term's candidate bucket — otherwise
@@ -1884,10 +1884,10 @@ def test_fqn_index_bucket_is_a_superset_of_the_truth_over_random_layouts(seed):
         truth = {full_name for full_name, info in peers.items() if DbtFactory._fqn_term_matches(term, info)}
         bucket = index._fqn_candidates(term)
         missing = truth - set(bucket)
-        assert not missing, f'term {term!r} truth-matches {sorted(missing)} but the index bucket omits them'
+        assert not missing, f"term {term!r} truth-matches {sorted(missing)} but the index bucket omits them"
 
 
-@pytest.mark.parametrize('seed', range(8))
+@pytest.mark.parametrize("seed", range(8))
 def test_index_narrowing_matches_a_full_scan_over_random_layouts(seed):
     # The generalisation of `test_selector_index_narrowing_matches_a_full_scan` off a single hand-built
     # layout: for each node's emitted selector the index-narrowed match set must equal the full-scan
@@ -1899,20 +1899,20 @@ def test_index_narrowing_matches_a_full_scan_over_random_layouts(seed):
         select = DbtFactory._node_select(info)
         scanned = sorted(DbtFactory._matching_ids(select, peers))
         narrowed = sorted(DbtFactory._matching_ids(select, index))
-        assert narrowed == scanned, f'{select!r} narrowed to {narrowed}, full scan gives {scanned}'
+        assert narrowed == scanned, f"{select!r} narrowed to {narrowed}, full scan gives {scanned}"
 
 
 def test_source_term_matches_only_the_named_source():
     peers = dict(
         [
-            _source('pkg', 'raw', 'orders'),
-            _source('pkg', 'raw', 'customers'),
-            _source('other', 'raw', 'orders'),
-            _model('pkg', 'orders'),
+            _source("pkg", "raw", "orders"),
+            _source("pkg", "raw", "customers"),
+            _source("other", "raw", "orders"),
+            _model("pkg", "orders"),
         ]
     )
 
-    assert DbtFactory._matching_ids('source:pkg.raw.orders', peers) == ['source.pkg.raw.orders']
+    assert DbtFactory._matching_ids("source:pkg.raw.orders", peers) == ["source.pkg.raw.orders"]
 
 
 def test_a_selector_that_reaches_nothing_is_refused(dbt_factory):
@@ -1924,17 +1924,17 @@ def test_a_selector_that_reaches_nothing_is_refused(dbt_factory):
     # reach a node the manifest files under a different package. That is a selector-construction bug
     # rather than a project problem, so the message says so.
     node = {
-        'resource_type': 'model',
-        'unique_id': 'model.pkg.orders',
-        'name': 'orders',
-        'package_name': 'pkg',
-        'fqn': ['pkg', 'orders'],
-        'original_file_path': 'models/orders.sql',
-        'depends_on': {'nodes': []},
+        "resource_type": "model",
+        "unique_id": "model.pkg.orders",
+        "name": "orders",
+        "package_name": "pkg",
+        "fqn": ["pkg", "orders"],
+        "original_file_path": "models/orders.sql",
+        "depends_on": {"nodes": []},
     }
-    peers = DbtFactory._selector_index({'model.pkg.orders': dict(node, package_name='other')})
+    peers = DbtFactory._selector_index({"model.pkg.orders": dict(node, package_name="other")})
 
-    with pytest.raises(ValueError, match='does not reach model.pkg.orders'):
+    with pytest.raises(ValueError, match="does not reach model.pkg.orders"):
         DbtFactory._node_select(node, peers=peers)
 
 
@@ -1981,20 +1981,20 @@ def test_gating_test_deps_are_ordered_deterministically_across_processes():
     orderings = set()
     for seed in range(8):
         result = subprocess.run(  # noqa: S603
-            [sys.executable, '-c', script],
+            [sys.executable, "-c", script],
             capture_output=True,
             text=True,
             check=False,
-            env={**os.environ, 'PYTHONHASHSEED': str(seed)},
+            env={**os.environ, "PYTHONHASHSEED": str(seed)},
             cwd=str(Path(BASE_PATH).parent),
         )
-        assert result.returncode == 0, f'seed {seed} failed:\n{result.stderr}'
+        assert result.returncode == 0, f"seed {seed} failed:\n{result.stderr}"
         orderings.add(result.stdout.strip())
 
     assert orderings == {'["d_model", "t_a_test", "t_m_test", "t_z_test"]'}
 
 
-@pytest.mark.parametrize('name', ['@weird', '2+orders'], ids=['at-prefix', 'numeric-prefix'])
+@pytest.mark.parametrize("name", ["@weird", "2+orders"], ids=["at-prefix", "numeric-prefix"])
 def test_leading_graph_operators_are_literal_under_an_explicit_fqn(dbt_factory, name):
     # dbt's `RAW_SELECTOR_PATTERN` reads a leading `@` or `N+` as a graph operator only when it is
     # inferring the method. Naming the method makes them literal: `fqn:@weird` and `fqn:2+orders` each
@@ -2003,12 +2003,12 @@ def test_leading_graph_operators_are_literal_under_an_explicit_fqn(dbt_factory, 
     #
     # A *trailing* `+N` is different and still refused; see
     # `test_name_fallback_ending_in_a_graph_operator_is_refused`.
-    nodes = dict([_model('pkg', name, fqn=['pkg', name], path=f'models/{name}.sql')])
+    nodes = dict([_model("pkg", name, fqn=["pkg", name], path=f"models/{name}.sql")])
 
-    tasks = dbt_factory.create_tasks({'nodes': nodes})
+    tasks = dbt_factory.create_tasks({"nodes": nodes})
 
-    assert [t['dbt_task']['commands'][0] for t in tasks] == [
-        f'dbt run --select fqn:pkg.{name},package:pkg,file:{name}.sql,resource_type:model --target dev'
+    assert [t["dbt_task"]["commands"][0] for t in tasks] == [
+        f"dbt run --select fqn:pkg.{name},package:pkg,file:{name}.sql,resource_type:model --target dev"
     ]
 
 
@@ -2020,11 +2020,11 @@ def test_bundled_test_for_a_parent_without_a_task_factory_is_refused():
     resolver = DbtDependencyResolver()
     task_options = DbtTaskOptions(source="GIT", environment_key="Default", task_type="dbt")
     factory = DbtFactory(
-        {'test': DbtTestTaskFactory(resolver, task_options, "--target dev")},
+        {"test": DbtTestTaskFactory(resolver, task_options, "--target dev")},
         bundle_tests=True,
     )
-    seed_name, seed_info = _seed('pkg', 'countries')
-    test_name, test_info = _test('pkg', 'not_null_countries_id', [seed_name], test_name='not_null')
+    seed_name, seed_info = _seed("pkg", "countries")
+    test_name, test_info = _test("pkg", "not_null_countries_id", [seed_name], test_name="not_null")
 
     with pytest.raises(ValueError, match=seed_name):
-        factory.create_tasks({'nodes': {seed_name: seed_info, test_name: test_info}})
+        factory.create_tasks({"nodes": {seed_name: seed_info, test_name: test_info}})

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -10,37 +10,37 @@ from databricks_dbt_factory import file_io
 
 
 def test_atomic_write_bytes_creates_parent_and_applies_content_and_mode(tmp_path: Path):
-    target = tmp_path / 'nested' / 'artifact.bin'
+    target = tmp_path / "nested" / "artifact.bin"
 
-    file_io.atomic_write_bytes(target, b'new content\x00', 0o640)
+    file_io.atomic_write_bytes(target, b"new content\x00", 0o640)
 
-    assert target.read_bytes() == b'new content\x00'
-    if os.name != 'nt':
+    assert target.read_bytes() == b"new content\x00"
+    if os.name != "nt":
         assert stat.S_IMODE(target.stat().st_mode) == 0o640
     assert list(target.parent.iterdir()) == [target]
 
 
 def test_atomic_write_bytes_supports_a_near_name_max_target(tmp_path: Path):
     try:
-        name_max = os.pathconf(tmp_path, 'PC_NAME_MAX')
+        name_max = os.pathconf(tmp_path, "PC_NAME_MAX")
     except (AttributeError, OSError, ValueError) as error:
-        pytest.skip(f'filesystem NAME_MAX is unavailable: {error}')
+        pytest.skip(f"filesystem NAME_MAX is unavailable: {error}")
     if name_max < 250:
-        pytest.skip(f'filesystem NAME_MAX {name_max} is too small for this regression')
+        pytest.skip(f"filesystem NAME_MAX {name_max} is too small for this regression")
 
     target = tmp_path / f"{'a' * 246}.bin"
     assert len(os.fsencode(target.name)) == 250
 
-    file_io.atomic_write_bytes(target, b'near name max', 0o600)
+    file_io.atomic_write_bytes(target, b"near name max", 0o600)
 
-    assert target.read_bytes() == b'near name max'
+    assert target.read_bytes() == b"near name max"
     assert list(tmp_path.iterdir()) == [target]
 
 
 def test_atomic_write_bytes_closes_hidden_same_directory_temp_before_replace(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    target = tmp_path / 'artifact.bin'
+    target = tmp_path / "artifact.bin"
     events: list[str] = []
     temporary_files: list[RecordingTemporaryFile] = []
     real_named_temporary_file = tempfile.NamedTemporaryFile
@@ -55,35 +55,35 @@ def test_atomic_write_bytes_closes_hidden_same_directory_temp_before_replace(
         return temporary_file
 
     def recording_fsync(file_descriptor: int):
-        events.append('fsync')
+        events.append("fsync")
         real_fsync(file_descriptor)
 
     def recording_chmod(path: os.PathLike[str] | str, mode: int):
-        events.append('chmod')
+        events.append("chmod")
         real_chmod(path, mode)
 
     def recording_replace(source: os.PathLike[str] | str, destination: os.PathLike[str] | str):
         source_path = Path(source)
         assert source_path.parent == target.parent
-        assert source_path.name.startswith('.dbf-')
+        assert source_path.name.startswith(".dbf-")
         assert temporary_files[0].closed
-        events.append('replace')
+        events.append("replace")
         real_replace(source, destination)
 
-    monkeypatch.setattr(file_io.tempfile, 'NamedTemporaryFile', recording_named_temporary_file)
-    monkeypatch.setattr(file_io.os, 'fsync', recording_fsync)
-    monkeypatch.setattr(file_io.os, 'chmod', recording_chmod)
-    monkeypatch.setattr(file_io.os, 'replace', recording_replace)
+    monkeypatch.setattr(file_io.tempfile, "NamedTemporaryFile", recording_named_temporary_file)
+    monkeypatch.setattr(file_io.os, "fsync", recording_fsync)
+    monkeypatch.setattr(file_io.os, "chmod", recording_chmod)
+    monkeypatch.setattr(file_io.os, "replace", recording_replace)
 
-    file_io.atomic_write_bytes(target, b'content', 0o600)
+    file_io.atomic_write_bytes(target, b"content", 0o600)
 
-    assert events == ['write', 'flush', 'fsync', 'chmod', 'close', 'replace']
+    assert events == ["write", "flush", "fsync", "chmod", "close", "replace"]
 
 
 def test_atomic_write_bytes_does_not_unlink_a_reused_temp_path_after_replace(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    target = tmp_path / 'artifact.bin'
+    target = tmp_path / "artifact.bin"
     replacement_path: Path | None = None
     real_replace = os.replace
 
@@ -91,43 +91,43 @@ def test_atomic_write_bytes_does_not_unlink_a_reused_temp_path_after_replace(
         nonlocal replacement_path
         replacement_path = Path(source)
         real_replace(source, destination)
-        replacement_path.write_bytes(b'new owner')
+        replacement_path.write_bytes(b"new owner")
 
-    monkeypatch.setattr(file_io.os, 'replace', replace_and_reuse_path)
+    monkeypatch.setattr(file_io.os, "replace", replace_and_reuse_path)
 
-    file_io.atomic_write_bytes(target, b'content', 0o600)
+    file_io.atomic_write_bytes(target, b"content", 0o600)
 
-    assert target.read_bytes() == b'content'
+    assert target.read_bytes() == b"content"
     assert replacement_path is not None
-    assert replacement_path.read_bytes() == b'new owner'
+    assert replacement_path.read_bytes() == b"new owner"
 
 
-@pytest.mark.parametrize('failure_point', ['write', 'fsync', 'chmod', 'replace'])
+@pytest.mark.parametrize("failure_point", ["write", "fsync", "chmod", "replace"])
 def test_atomic_write_bytes_cleans_temp_and_preserves_target_on_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure_point: str
 ):
-    target = tmp_path / 'artifact.bin'
-    target.write_bytes(b'original')
+    target = tmp_path / "artifact.bin"
+    target.write_bytes(b"original")
     real_named_temporary_file = tempfile.NamedTemporaryFile
 
-    if failure_point == 'write':
+    if failure_point == "write":
 
         def failing_named_temporary_file(*args, **kwargs):
             wrapped = real_named_temporary_file(*args, **kwargs)  # pylint: disable=consider-using-with
             return WriteFailingTemporaryFile(wrapped)
 
-        monkeypatch.setattr(file_io.tempfile, 'NamedTemporaryFile', failing_named_temporary_file)
+        monkeypatch.setattr(file_io.tempfile, "NamedTemporaryFile", failing_named_temporary_file)
     else:
 
         def fail(*args, **kwargs):
-            raise OSError(f'{failure_point} failed')
+            raise OSError(f"{failure_point} failed")
 
         monkeypatch.setattr(file_io.os, failure_point, fail)
 
-    with pytest.raises(OSError, match=rf'{failure_point} failed'):
-        file_io.atomic_write_bytes(target, b'replacement', 0o640)
+    with pytest.raises(OSError, match=rf"{failure_point} failed"):
+        file_io.atomic_write_bytes(target, b"replacement", 0o640)
 
-    assert target.read_bytes() == b'original'
+    assert target.read_bytes() == b"original"
     assert list(tmp_path.iterdir()) == [target]
 
 
@@ -142,15 +142,15 @@ class RecordingTemporaryFile:
 
     def __exit__(self, exc_type, exc_value, traceback):
         result = self._wrapped.__exit__(exc_type, exc_value, traceback)
-        self._events.append('close')
+        self._events.append("close")
         return result
 
     def write(self, content: bytes):
-        self._events.append('write')
+        self._events.append("write")
         return self._wrapped.write(content)
 
     def flush(self):
-        self._events.append('flush')
+        self._events.append("flush")
         return self._wrapped.flush()
 
     def fileno(self):
@@ -177,7 +177,7 @@ class WriteFailingTemporaryFile:
         return self._wrapped.__exit__(exc_type, exc_value, traceback)
 
     def write(self, content: bytes):
-        raise OSError('write failed')
+        raise OSError("write failed")
 
     @property
     def name(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,51 +10,51 @@ from databricks_dbt_factory.Utils import (
 
 
 def test_generate_task_key_readable_per_type():
-    assert generate_task_key('model.shop.orders') == 'orders_model'
-    assert generate_task_key('seed.shop.countries') == 'countries_seed'
-    assert generate_task_key('snapshot.shop.orders_snap') == 'orders_snap_snapshot'
-    assert generate_task_key('test.shop.unique_orders_id.9a1') == 'unique_orders_id_test'
-    assert generate_task_key('source.shop.raw.customers') == 'raw_customers_test'
+    assert generate_task_key("model.shop.orders") == "orders_model"
+    assert generate_task_key("seed.shop.countries") == "countries_seed"
+    assert generate_task_key("snapshot.shop.orders_snap") == "orders_snap_snapshot"
+    assert generate_task_key("test.shop.unique_orders_id.9a1") == "unique_orders_id_test"
+    assert generate_task_key("source.shop.raw.customers") == "raw_customers_test"
 
 
 def test_generate_task_key_keeps_model_version():
-    assert generate_task_key('model.shop.dim.v2') == 'dim_v2_model'
+    assert generate_task_key("model.shop.dim.v2") == "dim_v2_model"
 
 
 def test_build_task_key_maps_disambiguates_collisions():
     # Same model name in two packages -> keys must differ.
-    task_keys, _ = build_task_key_maps(['model.a.orders', 'model.b.orders'])
-    assert task_keys['model.a.orders'] != task_keys['model.b.orders']
-    assert set(task_keys.values()) == {'a_orders_model', 'b_orders_model'}
+    task_keys, _ = build_task_key_maps(["model.a.orders", "model.b.orders"])
+    assert task_keys["model.a.orders"] != task_keys["model.b.orders"]
+    assert set(task_keys.values()) == {"a_orders_model", "b_orders_model"}
 
 
 def test_build_task_key_maps_unique_names_stay_plain():
-    task_keys, _ = build_task_key_maps(['model.a.orders', 'model.a.customers'])
-    assert task_keys == {'model.a.orders': 'orders_model', 'model.a.customers': 'customers_model'}
+    task_keys, _ = build_task_key_maps(["model.a.orders", "model.a.customers"])
+    assert task_keys == {"model.a.orders": "orders_model", "model.a.customers": "customers_model"}
 
 
 def test_bundled_test_key():
-    assert bundled_test_key('model.shop.orders') == 'orders_test'
-    assert bundled_test_key('source.shop.raw.customers') == 'raw_customers_test'
+    assert bundled_test_key("model.shop.orders") == "orders_test"
+    assert bundled_test_key("source.shop.raw.customers") == "raw_customers_test"
 
 
 def test_generate_task_key_truncates_over_long_test_name():
-    long_name = 'x' * 200
-    key = generate_task_key(f'test.shop.{long_name}.9a1b2c')
+    long_name = "x" * 200
+    key = generate_task_key(f"test.shop.{long_name}.9a1b2c")
     assert len(key) == 100
-    assert key.endswith('_test')
-    assert '9a1b2c' in key
+    assert key.endswith("_test")
+    assert "9a1b2c" in key
 
 
 def test_generate_task_key_normal_test_name_not_truncated():
-    assert generate_task_key('test.shop.unique_orders_id.9a1') == 'unique_orders_id_test'
+    assert generate_task_key("test.shop.unique_orders_id.9a1") == "unique_orders_id_test"
 
 
 def test_build_task_key_maps_disambiguates_tests_via_hash():
-    task_keys, _ = build_task_key_maps(['test.a.dup_check.9a1', 'test.b.dup_check.7f2'])
-    assert task_keys['test.a.dup_check.9a1'] != task_keys['test.b.dup_check.7f2']
-    assert task_keys['test.a.dup_check.9a1'] == 'dup_check_9a1_test'
-    assert task_keys['test.b.dup_check.7f2'] == 'dup_check_7f2_test'
+    task_keys, _ = build_task_key_maps(["test.a.dup_check.9a1", "test.b.dup_check.7f2"])
+    assert task_keys["test.a.dup_check.9a1"] != task_keys["test.b.dup_check.7f2"]
+    assert task_keys["test.a.dup_check.9a1"] == "dup_check_9a1_test"
+    assert task_keys["test.b.dup_check.7f2"] == "dup_check_7f2_test"
 
 
 def test_build_task_key_maps_keys_do_not_depend_on_input_order():
@@ -62,7 +62,7 @@ def test_build_task_key_maps_keys_do_not_depend_on_input_order():
     # depend on manifest order, so adding an unrelated model can silently repoint a task key (and
     # with it, run history and task-level alerts) at a different model. Keys must be a function of
     # the node id alone.
-    ids = ['model.pkg.a_b', 'model.pkg.a.b']
+    ids = ["model.pkg.a_b", "model.pkg.a.b"]
     forward, _ = build_task_key_maps(ids)
     reverse, _ = build_task_key_maps(list(reversed(ids)))
 
@@ -71,9 +71,9 @@ def test_build_task_key_maps_keys_do_not_depend_on_input_order():
 
 
 def test_build_task_key_maps_key_is_stable_when_unrelated_node_added():
-    ids = ['model.pkg.a_b', 'model.pkg.a.b']
+    ids = ["model.pkg.a_b", "model.pkg.a.b"]
     before, _ = build_task_key_maps(ids)
-    after, _ = build_task_key_maps(ids + ['model.pkg.unrelated'])
+    after, _ = build_task_key_maps(ids + ["model.pkg.unrelated"])
 
     for uid in ids:
         assert before[uid] == after[uid]
@@ -83,39 +83,39 @@ def test_build_task_key_maps_numeric_suffix_when_disambiguated_key_collides():
     # `model.a.orders`'s plain key `orders_model` collides with `model.pkg.orders`, so it takes the
     # package-prefixed `a_orders_model` — which in turn collides with `model.pkg.a_orders`'s plain
     # key. The final guard appends `_2` to keep every key unique.
-    task_keys, _ = build_task_key_maps(['model.pkg.a_orders', 'model.a.orders', 'model.c.orders'])
-    assert task_keys['model.pkg.a_orders'] == 'a_orders_model'
-    assert task_keys['model.a.orders'] == 'a_orders_model_2'
-    assert task_keys['model.c.orders'] == 'c_orders_model'
+    task_keys, _ = build_task_key_maps(["model.pkg.a_orders", "model.a.orders", "model.c.orders"])
+    assert task_keys["model.pkg.a_orders"] == "a_orders_model"
+    assert task_keys["model.a.orders"] == "a_orders_model_2"
+    assert task_keys["model.c.orders"] == "c_orders_model"
     assert len(set(task_keys.values())) == 3
 
 
 def test_generate_task_key_rejects_malformed_id_missing_name():
     with pytest.raises(ValueError):
-        generate_task_key('model.pkg')
+        generate_task_key("model.pkg")
 
 
 def test_generate_task_key_rejects_source_id_missing_table():
     with pytest.raises(ValueError):
-        generate_task_key('source.pkg.raw')
+        generate_task_key("source.pkg.raw")
 
 
 def test_build_task_key_maps_disambiguates_bundled_test_collisions():
-    _, bundled_test_keys = build_task_key_maps([], bundled_test_ids=['model.a.orders', 'model.b.orders'])
-    assert bundled_test_keys['model.a.orders'] != bundled_test_keys['model.b.orders']
-    assert set(bundled_test_keys.values()) == {'a_orders_test', 'b_orders_test'}
+    _, bundled_test_keys = build_task_key_maps([], bundled_test_ids=["model.a.orders", "model.b.orders"])
+    assert bundled_test_keys["model.a.orders"] != bundled_test_keys["model.b.orders"]
+    assert set(bundled_test_keys.values()) == {"a_orders_test", "b_orders_test"}
 
 
 def test_build_task_key_maps_non_colliding_bundled_test_stays_plain():
-    _, bundled_test_keys = build_task_key_maps([], bundled_test_ids=['model.shop.orders'])
-    assert bundled_test_keys == {'model.shop.orders': 'orders_test'}
+    _, bundled_test_keys = build_task_key_maps([], bundled_test_ids=["model.shop.orders"])
+    assert bundled_test_keys == {"model.shop.orders": "orders_test"}
 
 
 def test_build_task_key_maps_bounds_over_long_model_keys():
     # Model/seed/snapshot keys were previously unbounded; a very long model name must now be
     # truncated to the limit and stay distinct from a near-identical over-long sibling.
-    long_a = 'model.shop.' + 'a' * 130
-    long_b = 'model.shop.' + 'a' * 129 + 'b'
+    long_a = "model.shop." + "a" * 130
+    long_b = "model.shop." + "a" * 129 + "b"
     task_keys, _ = build_task_key_maps([long_a, long_b])
     assert len(task_keys[long_a]) <= MAX_TASK_KEY_LENGTH
     assert len(task_keys[long_b]) <= MAX_TASK_KEY_LENGTH
@@ -125,8 +125,8 @@ def test_build_task_key_maps_bounds_over_long_model_keys():
 def test_build_task_key_maps_bounds_over_long_collision_fallback():
     # Two same-named models in different packages collide; the disambiguated fallback is itself
     # over-long, so it must be bounded while remaining unique.
-    model_a = 'model.' + 'p' * 60 + '.' + 'm' * 60
-    model_b = 'model.' + 'q' * 60 + '.' + 'm' * 60
+    model_a = "model." + "p" * 60 + "." + "m" * 60
+    model_b = "model." + "q" * 60 + "." + "m" * 60
     task_keys, _ = build_task_key_maps([model_a, model_b])
     assert len(task_keys[model_a]) <= MAX_TASK_KEY_LENGTH
     assert len(task_keys[model_b]) <= MAX_TASK_KEY_LENGTH
@@ -134,7 +134,7 @@ def test_build_task_key_maps_bounds_over_long_collision_fallback():
 
 
 def test_build_task_key_maps_bounds_over_long_bundled_key():
-    long_model = 'model.shop.' + 'z' * 130
+    long_model = "model.shop." + "z" * 130
     task_keys, bundled_test_keys = build_task_key_maps([long_model], bundled_test_ids=[long_model])
     assert len(task_keys[long_model]) <= MAX_TASK_KEY_LENGTH
     assert len(bundled_test_keys[long_model]) <= MAX_TASK_KEY_LENGTH
@@ -142,30 +142,30 @@ def test_build_task_key_maps_bounds_over_long_bundled_key():
 
 
 def test_read_dbt_manifest_roundtrip(tmp_path):
-    manifest_path = tmp_path / 'manifest.json'
-    manifest_path.write_text('{"nodes": {}}', encoding='utf-8')
-    assert read_dbt_manifest(str(manifest_path)) == {'nodes': {}}
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text('{"nodes": {}}', encoding="utf-8")
+    assert read_dbt_manifest(str(manifest_path)) == {"nodes": {}}
 
 
 def test_read_dbt_manifest_missing_file_raises():
     with pytest.raises(FileNotFoundError):
-        read_dbt_manifest('/no/such/manifest.json')
+        read_dbt_manifest("/no/such/manifest.json")
 
 
 def test_read_dbt_manifest_invalid_json_raises(tmp_path):
-    manifest_path = tmp_path / 'manifest.json'
-    manifest_path.write_text('{not json', encoding='utf-8')
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text("{not json", encoding="utf-8")
     with pytest.raises(ValueError):
         read_dbt_manifest(str(manifest_path))
 
 
-@pytest.mark.parametrize('payload', ['[]', '"just a string"', '7', 'null'], ids=['list', 'string', 'int', 'null'])
+@pytest.mark.parametrize("payload", ["[]", '"just a string"', "7", "null"], ids=["list", "string", "int", "null"])
 def test_read_dbt_manifest_rejects_non_object_json(tmp_path, payload):
     # Valid JSON that is not an object parses fine here, then `manifest.get('nodes', {})` in the
     # factory raises AttributeError, which `main`'s `except (ValueError, FileNotFoundError)` does not
     # catch — the CLI aborts with a traceback for a malformed *input file*. Reject it as a
     # user-fixable ValueError, like a parse error.
-    manifest_path = tmp_path / 'manifest.json'
-    manifest_path.write_text(payload, encoding='utf-8')
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(payload, encoding="utf-8")
     with pytest.raises(ValueError):
         read_dbt_manifest(str(manifest_path))


### PR DESCRIPTION
## What

Replace the formatter — **black** (with `skip-string-normalization = true`, which kept single quotes) → **`ruff format`**, whose default double-quote style matches the [`databricks/bundle-examples`](https://github.com/databricks/bundle-examples/pull/163) repo.

The motivation is byte-identity. bundle-examples PR #163 vendors this repo's core (adapted from `edbbd7c`, v0.3.3) and reformats it with `ruff format` at `line-length = 120` + double quotes, so its copy was only *AST-identical* to ours, not textually identical. Adopting the same formatter here makes the two **byte-for-byte identical**, so future re-syncs are a clean `diff`.

## Changes

- **`pyproject.toml`**: drop `black`, bump `ruff` `~=0.3.4` → `~=0.12.0`, use `ruff format` in the `fmt`/`verify` hatch scripts, remove `[tool.black]`. `[tool.ruff]` keeps `line-length = 120` and the `notebook` exclude.
- **Reformat the repo** with `ruff format`: quote normalization (single → double) plus minor reflow. No behaviour change — only string delimiters and wrapping.

## Verification

- **Byte-identity** confirmed with `diff` against bundle-examples PR #163's vendored copy for every shared file — `DbtFactory.py`, `DbtTask.py`, `TaskFactory.py`, `Utils.py`, `__about__.py`, `notebook/run_dbt_command.py`.
- Format output is **stable across ruff 0.9.0 → 0.16.2** (0.8.0 differs); the `~=0.12.0` pin sits inside that range.
- `make test` → **317 passed**.
- `make lint` → `ruff format --check`, `ruff check`, `mypy`, and `pylint` **10.00/10** all clean. CI's `fmt` job (`make fmt` + `git diff --exit-code`) produces no diff.

This pull request and its description were written by Isaac.