### PR TITLE
chore: drop DQX config leftovers from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,9 +94,6 @@ verify      = ["black --check .",
                "mypy .",
                "pylint --output-format=colorized -j 0 src tests"]
 
-[tool.isort]
-profile = "black"
-
 [tool.mypy]
 exclude = ['venv', '.venv', 'src/databricks_dbt_factory/notebook']
 ignore_missing_imports = true
@@ -123,14 +120,14 @@ line-length = 120
 extend-exclude = ["src/databricks_dbt_factory/notebook"]
 
 [tool.ruff.lint.isort]
-known-first-party = ["databricks.labs.dqx"]
+known-first-party = ["databricks_dbt_factory"]
 
 [tool.coverage.run]
 branch = true
 parallel = true
 
 [tool.coverage.report]
-omit = ["*/working-copy/*", 'src/databricks/labs/dqx/__main__.py']
+omit = ["*/working-copy/*"]
 exclude_lines = [
     "no cov",
     "if __name__ == .__main__.:",


### PR DESCRIPTION
## What

`pyproject.toml` was seeded from the [`databricks-labs-dqx`](https://github.com/databrickslabs/dqx) project, and three references to it were never updated for `databricks_dbt_factory`. All three are **inert today**, so this is pure config cleanup — no behaviour change:

- **Remove the dead `[tool.isort]` section.** Standalone `isort` isn't a dependency; import sorting would run through ruff. (And its `profile = "black"` is now doubly stale.)
- **Fix `[tool.ruff.lint.isort] known-first-party`** → `databricks_dbt_factory` (was `databricks.labs.dqx`). ruff's isort (`I`) rules aren't in the `select` set, so this is currently inert and reorders nothing — but it makes first-party grouping correct if `I` is ever enabled.
- **Drop the `src/databricks/labs/dqx/__main__.py` coverage-omit entry** — no such path exists here.

`databricks.labs.pylint.all` in `load-plugins` is intentionally kept — it's a real, installed pylint plugin (backed by the `databricks-labs-pylint` dependency).

## Verification

- `make lint` → `black --check`, `ruff check`, `mypy`, `pylint` **10.00/10**, all clean.
- `make test` → **317 passed**.
- Confirmed `I` (isort) is not selected, so the `known-first-party` change produces no import reordering.

Independent of #32 (formatter migration); the two touch non-overlapping regions of `pyproject.toml`.

This pull request and its description were written by Isaac.