### PR TITLE
feat: authenticate the notebook runner via the Databricks SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,11 @@ commands, whether it backs native dbt tasks or notebook tasks. Databricks recomm
 `dbt-databricks>=1.6.0`; matching the manifest-generation version exactly is the stronger
 compatibility requirement.
 
+The packaged notebook runner authenticates through the Databricks SDK (`databricks-sdk`), which
+`dbt-databricks` already depends on — so the `dbt-databricks` pin above covers it. A custom task
+environment that omits `dbt-databricks` must install `databricks-sdk` as well, or the runner fails
+at import.
+
 The example uses [serverless environment version 5](https://docs.databricks.com/aws/en/release-notes/serverless/environment-version/five),
 the current Databricks environment version. Use the latest version available in your workspace.
 

--- a/README.md
+++ b/README.md
@@ -591,6 +591,13 @@ Each task calls the shared content-addressed
 - Supports running the dbt process on job compute via `--job-cluster-key` (SQL execution still uses the warehouse in `profiles.yml`)
 - More flexibility — pass `--notebook-path` to manage and extend your own runner when you need custom secrets, APIs, notifications, or run metadata.
 
+**Limitation — authentication token lifetime:** the runner authenticates dbt with the notebook's
+own credentials, captured once into `DBT_ACCESS_TOKEN` at the start of the run. That token is
+short-lived (about one hour) and does not self-refresh, so a single task that runs longer than the
+token's lifetime can fail mid-run with an authentication error. This is not a concern for typical
+runs — dbt pushes the SQL to the warehouse and mostly waits, so individual tasks rarely exceed an
+hour.
+
 #### Faster parsing on large projects (pre-built msgpack)
 
 On large projects with many parallel tasks, most of each task's time is dbt **parsing** (re-reading

--- a/src/databricks_dbt_factory/notebook/run_dbt_command.py
+++ b/src/databricks_dbt_factory/notebook/run_dbt_command.py
@@ -25,11 +25,9 @@ if not dbt_commands:
 
 # COMMAND ----------
 
-# Authenticate dbt with the notebook's own credentials via the Databricks SDK. On job/notebook
-# compute `WorkspaceClient()` resolves the run's ambient credentials without any configuration, and
-# `authenticate()` returns a ready-to-use `Authorization: Bearer <token>` header. The captured token
+# Authenticate dbt with the notebook's own credentials via the Databricks SDK. The captured token
 # is short-lived (about an hour) and does not self-refresh, so a single task running longer than its
-# lifetime can fail mid-run — see the README's notebook-task limitations.
+# lifetime can fail mid-run.
 ws = WorkspaceClient()
 os.environ["DBT_ACCESS_TOKEN"] = ws.config.authenticate()["Authorization"].removeprefix("Bearer ").strip()
 

--- a/src/databricks_dbt_factory/notebook/run_dbt_command.py
+++ b/src/databricks_dbt_factory/notebook/run_dbt_command.py
@@ -25,9 +25,11 @@ if not dbt_commands:
 
 # COMMAND ----------
 
-# Authenticate dbt with the notebook's own credentials via the Databricks SDK. 
-# It is short-lived and does not self-refresh, so a
-# single task running longer than the token's lifetime (about an hour) can fail mid-run
+# Authenticate dbt with the notebook's own credentials via the Databricks SDK. On job/notebook
+# compute `WorkspaceClient()` resolves the run's ambient credentials without any configuration, and
+# `authenticate()` returns a ready-to-use `Authorization: Bearer <token>` header. The captured token
+# is short-lived (about an hour) and does not self-refresh, so a single task running longer than its
+# lifetime can fail mid-run — see the README's notebook-task limitations.
 ws = WorkspaceClient()
 os.environ["DBT_ACCESS_TOKEN"] = ws.config.authenticate()["Authorization"].removeprefix("Bearer ").strip()
 

--- a/src/databricks_dbt_factory/notebook/run_dbt_command.py
+++ b/src/databricks_dbt_factory/notebook/run_dbt_command.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 from urllib.parse import urlparse
 
+from databricks.sdk import WorkspaceClient
 from dbt.cli.main import dbtRunner
 
 # COMMAND ----------
@@ -24,13 +25,16 @@ if not dbt_commands:
 
 # COMMAND ----------
 
-ctx = dbutils.notebook.entry_point.getDbutils().notebook().getContext()
-os.environ["DBT_ACCESS_TOKEN"] = ctx.apiToken().get()
-# dbt's host must be a bare hostname, but apiUrl() returns a full URL (scheme + host, and
-# potentially a trailing slash or path). Parse it and keep only the netloc so a value like
+# Authenticate dbt with the notebook's own credentials via the Databricks SDK. 
+# It is short-lived and does not self-refresh, so a
+# single task running longer than the token's lifetime (about an hour) can fail mid-run
+ws = WorkspaceClient()
+os.environ["DBT_ACCESS_TOKEN"] = ws.config.authenticate()["Authorization"].removeprefix("Bearer ").strip()
+
+# dbt's host must be a bare hostname, but `config.host` is a full URL (scheme + host, and potentially
+# a trailing slash or path). Parse it and keep only the netloc so a value like
 # "https://my-workspace.databricks.com/" yields "my-workspace.databricks.com".
-_api_url = ctx.apiUrl().get()
-_parsed = urlparse(_api_url)
+_parsed = urlparse(ws.config.host)
 os.environ["DBT_HOST"] = _parsed.netloc or _parsed.path.strip("/")
 
 # chdir to the dbt project so dbt runs from inside it. Relative `project_directory` is
@@ -40,6 +44,7 @@ os.environ["DBT_HOST"] = _parsed.netloc or _parsed.path.strip("/")
 # `--project-directory` resolves against wherever the user placed the notebook; absolute
 # `project_directory` is used as-is.
 if project_directory:
+    ctx = dbutils.notebook.entry_point.getDbutils().notebook().getContext()
     notebook_dir = os.path.dirname("/Workspace" + ctx.notebookPath().get())
     target_dir = (
         project_directory

--- a/tests/integration/test_selector_against_dbt.py
+++ b/tests/integration/test_selector_against_dbt.py
@@ -2745,41 +2745,25 @@ def test_shipped_runner_authenticates_dbt_from_the_workspace_client(tmp_path, mo
     """
     The runner captures the WorkspaceClient's token and host into `DBT_ACCESS_TOKEN`/`DBT_HOST`.
 
-    Those env vars are cleared in the runner's `finally`, so this asserts the behaviour rather than
-    the leftover values: the profile reads both through dbt's `env_var()`, which raises for an unset
-    variable, so a `dbt ls` that resolves the node at all proves the runner set each from the stubbed
-    client before invoking dbt.
+    The runner clears both env vars in its `finally`, so this records their values at the moment the
+    runner pops them and asserts those, rather than reading leftovers. `dbt ls` parses but never opens
+    a connection, so dbt itself cannot witness the token or an empty host; the exported values are
+    asserted directly. Running the full runner additionally proves the auth block does not raise and
+    that dbt still resolves the node end to end.
     """
-    # Parse and build the selector against the static profile, so the prep steps (which run before the
-    # runner sets any env var) do not themselves depend on `DBT_HOST`/`DBT_ACCESS_TOKEN`.
     _write_project(tmp_path, {"orders.sql": MODEL_SQL})
     manifest = _parse(tmp_path)
     unique_id = "model.probe.orders"
     _task_key, selectors, verb = _resource_selectors(manifest, bundle_tests=False)[0]
     assert verb == "run"
 
-    # Swap in a profile whose host reads through dbt's `env_var()` only for the runner run, starting
-    # from an unset `DBT_HOST` so a runner that fails to set it surfaces as dbt's `env_var()` error at
-    # parse time rather than reusing an ambient value. `dbt ls` parses but never authenticates, so the
-    # host — which parsing does resolve — is what a templated profile can prove; the token is asserted
-    # directly below from the value the runner wrote into the environment.
-    templated_profile = (
-        "probe:\n"
-        "  target: dev\n"
-        "  outputs:\n"
-        "    dev:\n"
-        "      type: databricks\n"
-        "      host: \"{{ env_var('DBT_HOST') }}\"\n"
-        "      http_path: /sql/1.0/warehouses/x\n"
-        "      token: dummy\n"
-        "      schema: default\n"
-    )
-    (tmp_path / "profiles.yml").write_text(templated_profile, encoding="utf-8")
+    # Start from an environment where neither variable carries an ambient value, so the recorded
+    # values below can only be what this runner exported.
     monkeypatch.delenv("DBT_HOST", raising=False)
     monkeypatch.delenv("DBT_ACCESS_TOKEN", raising=False)
 
-    # Capture the token the runner exports before its `finally` clears it, by recording the value at
-    # the moment the runner pops it from the environment.
+    # Capture the credentials the runner exports before its `finally` clears them, by recording each
+    # value at the moment the runner pops it from the environment.
     popped: dict[str, str] = {}
     real_pop = os.environ.pop
 
@@ -2792,12 +2776,13 @@ def test_shipped_runner_authenticates_dbt_from_the_workspace_client(tmp_path, mo
 
     namespace = _run_shipped_notebook(monkeypatch, tmp_path, selectors)
 
-    # dbt resolved the templated host, so the runner set `DBT_HOST` from the stubbed client's host,
-    # reduced to a bare netloc.
+    # The full runner executed without the auth block raising, and dbt resolved the node.
     assert _runner_result_ids(namespace) == (unique_id,)
-    assert namespace["_parsed"].netloc == "example.databricks.com"
-    # The runner authenticated through the stubbed client and exported its bearer token and host.
+    # The runner authenticated through the stubbed client and exported its bearer token and bare host.
     assert _StubWorkspaceClient.last is not None and _StubWorkspaceClient.last.config.authenticated
+    assert popped["DBT_ACCESS_TOKEN"] == _STUB_RUNNER_TOKEN
+    assert popped["DBT_HOST"] == "example.databricks.com"
+    assert namespace["_parsed"].netloc == "example.databricks.com"
     assert popped["DBT_ACCESS_TOKEN"] == _STUB_RUNNER_TOKEN
     assert popped["DBT_HOST"] == "example.databricks.com"
 

--- a/tests/integration/test_selector_against_dbt.py
+++ b/tests/integration/test_selector_against_dbt.py
@@ -2544,14 +2544,42 @@ class _NotebookWidgets:
 def _notebook_dbutils(values: dict[str, str]):
     """Builds the minimal `dbutils` object needed to execute the packaged notebook locally."""
     context = SimpleNamespace(
-        apiToken=lambda: _NotebookValue("token"),
-        apiUrl=lambda: _NotebookValue("https://example.databricks.com/"),
         notebookPath=lambda: _NotebookValue("/Workspace/project/run_dbt_command.py"),
     )
     notebook = SimpleNamespace(getContext=lambda: context)
     backend = SimpleNamespace(notebook=lambda: notebook)
     entry_point = SimpleNamespace(getDbutils=lambda: backend)
     return SimpleNamespace(widgets=_NotebookWidgets(values), notebook=SimpleNamespace(entry_point=entry_point))
+
+
+# The token and host a stubbed `WorkspaceClient` hands the runner, so the notebook executes offline —
+# `dbt ls`/parse needs no warehouse, and constructing a real `WorkspaceClient` would demand ambient
+# Databricks credentials CI does not have.
+_STUB_RUNNER_TOKEN = "stub-access-token"
+_STUB_RUNNER_HOST_URL = "https://example.databricks.com/"
+
+
+class _StubWorkspaceConfig:
+    """The `config` surface the runner reads: an auth header factory and the workspace host URL."""
+
+    def __init__(self):
+        self.host = _STUB_RUNNER_HOST_URL
+        self.authenticated = False
+
+    def authenticate(self) -> dict[str, str]:
+        self.authenticated = True
+        return {"Authorization": f"Bearer {_STUB_RUNNER_TOKEN}"}
+
+
+class _StubWorkspaceClient:
+    """Stands in for `databricks.sdk.WorkspaceClient` so the runner authenticates without a workspace."""
+
+    #: The most recently constructed stub, so a test can assert the runner consumed its credentials.
+    last: "_StubWorkspaceClient | None" = None
+
+    def __init__(self, *_args, **_kwargs):
+        self.config = _StubWorkspaceConfig()
+        _StubWorkspaceClient.last = self
 
 
 def _run_shipped_notebook(monkeypatch, root: Path, selectors: tuple[str, ...]) -> dict:
@@ -2570,6 +2598,9 @@ def _run_shipped_notebook(monkeypatch, root: Path, selectors: tuple[str, ...]) -
     )
     with monkeypatch.context() as execution:
         execution.chdir(root)
+        # The runner imports `WorkspaceClient` at module top and constructs it at run time; patch the
+        # source module so the fresh `runpy` import binds the stub instead of the real SDK client.
+        execution.setattr("databricks.sdk.WorkspaceClient", _StubWorkspaceClient)
         for name in ("DBT_ACCESS_TOKEN", "DBT_HOST", "DBT_TARGET_PATH", "DBT_LOG_PATH"):
             execution.setenv(name, os.environ.get(name, ""))
         return runpy.run_path(str(runner_path), init_globals={"dbutils": _notebook_dbutils(values)})
@@ -2708,6 +2739,67 @@ def test_shipped_runner_falls_back_to_live_parse_when_manifest_is_unavailable(
     assert namespace["runner"].manifest is None
     assert _runner_result_ids(namespace) == (unique_id,)
     assert (fallback_message in output) is expects_fallback_message
+
+
+def test_shipped_runner_authenticates_dbt_from_the_workspace_client(tmp_path, monkeypatch):
+    """
+    The runner captures the WorkspaceClient's token and host into `DBT_ACCESS_TOKEN`/`DBT_HOST`.
+
+    Those env vars are cleared in the runner's `finally`, so this asserts the behaviour rather than
+    the leftover values: the profile reads both through dbt's `env_var()`, which raises for an unset
+    variable, so a `dbt ls` that resolves the node at all proves the runner set each from the stubbed
+    client before invoking dbt.
+    """
+    # Parse and build the selector against the static profile, so the prep steps (which run before the
+    # runner sets any env var) do not themselves depend on `DBT_HOST`/`DBT_ACCESS_TOKEN`.
+    _write_project(tmp_path, {"orders.sql": MODEL_SQL})
+    manifest = _parse(tmp_path)
+    unique_id = "model.probe.orders"
+    _task_key, selectors, verb = _resource_selectors(manifest, bundle_tests=False)[0]
+    assert verb == "run"
+
+    # Swap in a profile whose host reads through dbt's `env_var()` only for the runner run, starting
+    # from an unset `DBT_HOST` so a runner that fails to set it surfaces as dbt's `env_var()` error at
+    # parse time rather than reusing an ambient value. `dbt ls` parses but never authenticates, so the
+    # host — which parsing does resolve — is what a templated profile can prove; the token is asserted
+    # directly below from the value the runner wrote into the environment.
+    templated_profile = (
+        "probe:\n"
+        "  target: dev\n"
+        "  outputs:\n"
+        "    dev:\n"
+        "      type: databricks\n"
+        "      host: \"{{ env_var('DBT_HOST') }}\"\n"
+        "      http_path: /sql/1.0/warehouses/x\n"
+        "      token: dummy\n"
+        "      schema: default\n"
+    )
+    (tmp_path / "profiles.yml").write_text(templated_profile, encoding="utf-8")
+    monkeypatch.delenv("DBT_HOST", raising=False)
+    monkeypatch.delenv("DBT_ACCESS_TOKEN", raising=False)
+
+    # Capture the token the runner exports before its `finally` clears it, by recording the value at
+    # the moment the runner pops it from the environment.
+    popped: dict[str, str] = {}
+    real_pop = os.environ.pop
+
+    def _recording_pop(key, *default):
+        if key in {"DBT_ACCESS_TOKEN", "DBT_HOST"} and key in os.environ:
+            popped[key] = os.environ[key]
+        return real_pop(key, *default)
+
+    monkeypatch.setattr(os.environ, "pop", _recording_pop)
+
+    namespace = _run_shipped_notebook(monkeypatch, tmp_path, selectors)
+
+    # dbt resolved the templated host, so the runner set `DBT_HOST` from the stubbed client's host,
+    # reduced to a bare netloc.
+    assert _runner_result_ids(namespace) == (unique_id,)
+    assert namespace["_parsed"].netloc == "example.databricks.com"
+    # The runner authenticated through the stubbed client and exported its bearer token and host.
+    assert _StubWorkspaceClient.last is not None and _StubWorkspaceClient.last.config.authenticated
+    assert popped["DBT_ACCESS_TOKEN"] == _STUB_RUNNER_TOKEN
+    assert popped["DBT_HOST"] == "example.databricks.com"
 
 
 @pytest.mark.parametrize("seed", range(12))


### PR DESCRIPTION
## What

Switches the packaged notebook runner (`run_dbt_command.py`) from the `dbutils` notebook-context token (`ctx.apiToken()`/`ctx.apiUrl()`) to the Databricks SDK:

```python
ws = WorkspaceClient()
os.environ["DBT_ACCESS_TOKEN"] = ws.config.authenticate()["Authorization"].removeprefix("Bearer ").strip()
_parsed = urlparse(ws.config.host)
os.environ["DBT_HOST"] = _parsed.netloc or _parsed.path.strip("/")
```

`WorkspaceClient()` resolves the run's ambient credentials on notebook/job compute with no configuration. The `dbutils` context is still consulted only for the notebook's own path, when a relative `--project-directory` must be resolved.

## Why not native OAuth

Token-less `auth_type: oauth` was evaluated and rejected: the dbt-databricks adapter (1.12.3) resolves it to the SDK's **interactive external-browser** provider, which cannot run headless on a job cluster. Verified against a live workspace.

## Known limitation (documented in README)

The captured token is short-lived (~1h, measured from its `exp`) and does not self-refresh, so a single task running longer than its lifetime can fail mid-run. Rare in practice — dbt offloads SQL to the warehouse and mostly waits.

## Tests

- The shipped-runner integration harness now stubs `WorkspaceClient` so it executes offline (previously it would have demanded real credentials — my initial change broke it, this restores it).
- New focused test asserting the runner exports `DBT_ACCESS_TOKEN` and `DBT_HOST` from the client (teeth-verified: fails if either export is removed/wrong).
- Unit suite (317) and runner integration subset (6) pass offline; `make lint` clean (10.00/10).

This pull request and its description were written by Isaac.